### PR TITLE
Add system dark mode (prefers-color-scheme)

### DIFF
--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: Launch the dot-pe Gatsby dev server and take browser screenshots
+---
+
+# Run skill: dot-pe Gatsby site
+
+## Launch
+
+Dependencies are not pre-installed. Install first if `node_modules` is missing:
+
+```bash
+[ -d node_modules ] || npm install
+```
+
+Start the dev server in the background:
+
+```bash
+./node_modules/.bin/gatsby develop --port 8000 > /tmp/gatsby-dev.log 2>&1 &
+```
+
+Wait for it to be ready (takes ~20-30s):
+
+```bash
+for i in $(seq 1 40); do
+  curl -s http://localhost:8000 > /dev/null 2>&1 && echo "Ready" && break
+  sleep 3
+done
+```
+
+Check logs if it doesn't come up: `tail -20 /tmp/gatsby-dev.log`
+
+## Take screenshots
+
+Use Playwright via the global install at `/opt/node22/lib/node_modules/playwright/index.mjs`.
+Use `waitUntil: 'load'` — NOT `networkidle` (Gatsby's hot-reload websocket keeps the connection open and causes a timeout).
+
+```js
+import { chromium } from "/opt/node22/lib/node_modules/playwright/index.mjs"
+
+const browser = await chromium.launch()
+
+for (const scheme of ["light", "dark"]) {
+  const ctx = await browser.newContext({
+    colorScheme: scheme,
+    viewport: { width: 1280, height: 900 },
+  })
+  const page = await ctx.newPage()
+  await page.goto("http://localhost:8000", {
+    waitUntil: "load",
+    timeout: 15000,
+  })
+  await page.waitForTimeout(1500) // let JS hydrate
+  await page.screenshot({ path: `/tmp/${scheme}.png` })
+  await ctx.close()
+}
+
+await browser.close()
+```
+
+Save as a `.mjs` file and run with `node`.
+
+## Key URLs
+
+- Home: `http://localhost:8000/`
+- Posts: `http://localhost:8000/posts/`
+- Individual post: `http://localhost:8000/on-gaining-a-civic-voice-with-llms/`
+- Swedish version: `http://localhost:8000/sv/`

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -63,5 +63,5 @@ Save as a `.mjs` file and run with `node`.
 
 - Home: `http://localhost:8000/`
 - Posts: `http://localhost:8000/posts/`
-- Individual post: `http://localhost:8000/on-gaining-a-civic-voice-with-llms/`
+- Individual post: `http://localhost:8000/writes/on-gaining-a-civic-voice-with-llms/`
 - Swedish version: `http://localhost:8000/sv/`

--- a/.claude/skills/run/SKILL.md
+++ b/.claude/skills/run/SKILL.md
@@ -31,11 +31,39 @@ Check logs if it doesn't come up: `tail -20 /tmp/gatsby-dev.log`
 
 ## Take screenshots
 
-Use Playwright via the global install at `/opt/node22/lib/node_modules/playwright/index.mjs`.
-Use `waitUntil: 'load'` — NOT `networkidle` (Gatsby's hot-reload websocket keeps the connection open and causes a timeout).
+Use Playwright. Resolve it from the project's `node_modules` if present, otherwise
+fall back to a global install (the Claude Code remote environment has one at
+`/opt/node22/lib/node_modules/playwright`):
 
 ```js
-import { chromium } from "/opt/node22/lib/node_modules/playwright/index.mjs"
+import { createRequire } from "module"
+import { existsSync } from "fs"
+
+const localPw = new URL(
+  "../../node_modules/playwright/index.js",
+  import.meta.url
+).pathname
+const globalPw = "/opt/node22/lib/node_modules/playwright/index.mjs"
+const pwPath = existsSync(localPw) ? localPw : globalPw
+
+const { chromium } = await import(pwPath)
+const browser = await chromium.launch()
+```
+
+Use `waitUntil: 'load'` — NOT `networkidle` (Gatsby's hot-reload websocket keeps
+the connection open and causes a timeout).
+
+Full example:
+
+```js
+import { existsSync } from "fs"
+
+const localPw = new URL(
+  "../../node_modules/playwright/index.js",
+  import.meta.url
+).pathname
+const globalPw = "/opt/node22/lib/node_modules/playwright/index.mjs"
+const { chromium } = await import(existsSync(localPw) ? localPw : globalPw)
 
 const browser = await chromium.launch()
 
@@ -57,7 +85,8 @@ for (const scheme of ["light", "dark"]) {
 await browser.close()
 ```
 
-Save as a `.mjs` file and run with `node`.
+Save as a `.mjs` file and run with `node`. If Playwright isn't available anywhere,
+install it: `npm install --save-dev playwright` then `npx playwright install chromium`.
 
 ## Key URLs
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -67,7 +67,7 @@ module.exports = {
       options: {
         postCssPlugins: [
           require("postcss-easy-import")(),
-          require("postcss-custom-properties")({ preserve: false }),
+          require("postcss-custom-properties")({ preserve: true }),
           require("autoprefixer")(),
         ],
       },

--- a/src/utils/css/components/buttons.css
+++ b/src/utils/css/components/buttons.css
@@ -86,8 +86,9 @@ input[type="button"]:hover,
 button:hover,
 .button:hover {
     text-decoration: none;
-    color: color(var(--color-primary) l(-15%)) !important;
-    box-shadow: inset 0 0 0 2px color(var(--color-primary) l(-10%));
+    color: var(--color-primary) !important;
+    box-shadow: inset 0 0 0 2px var(--color-primary);
+    opacity: 0.8;
     transition: 0.2s ease;
 }
 
@@ -106,5 +107,6 @@ input[type="reset"].primary:hover,
 input[type="button"].primary:hover,
 button.primary:hover,
 .button.primary:hover {
-        background-color: color(var(--color-primary) l(-10%));
+        background-color: var(--color-primary);
+        opacity: 0.85;
     }

--- a/src/utils/css/components/dark-mode.css
+++ b/src/utils/css/components/dark-mode.css
@@ -1,0 +1,63 @@
+/* Dark Mode Overrides
+/* ---------------------------------------------------------- */
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: var(--color-bg);
+    }
+
+    ::selection {
+        background: #1a6b9a;
+        color: #fff;
+    }
+
+    mark {
+        background-color: #4a4400;
+        color: #e8e8e8;
+    }
+
+    /* Mobile nav open state */
+    .site-head-open {
+        background: rgba(26, 26, 26, 1);
+    }
+
+    /* Code blocks */
+    .post-content-body pre {
+        border-color: #333;
+        background: #111;
+    }
+
+    .post-content-body code {
+        background: #2d2d2d;
+        color: var(--color-base);
+    }
+
+    /* Post cards without images: lighten the counter number */
+    .post-card.no-image:before {
+        color: rgba(255, 255, 255, 0.1);
+    }
+
+    /* Subscribe button border */
+    .subscribe-button {
+        border-color: var(--color-base);
+        color: var(--color-base);
+    }
+
+    /* Prism syntax highlighting adjustments */
+    .token.comment,
+    .token.prolog,
+    .token.doctype,
+    .token.cdata {
+        color: #8292a2;
+    }
+}
+
+@media (prefers-color-scheme: dark) and (max-width: 850px) {
+    .site-head-container {
+        background: rgba(26, 26, 26, 0);
+    }
+
+    .site-head-open .site-head-container {
+        background: rgba(26, 26, 26, 1);
+    }
+}

--- a/src/utils/css/components/global.css
+++ b/src/utils/css/components/global.css
@@ -260,7 +260,7 @@ html {
 }
 body {
     overflow-x: hidden;
-    color: color(var(--color-base) l(+20%));
+    color: var(--color-base);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
     font-size: 1.5rem;
     line-height: 1.6em;
@@ -288,7 +288,7 @@ hr {
     padding: 0;
     height: 1px;
     border: 0;
-    border-top: 1px solid #cfcfcf;
+    border-top: 1px solid var(--color-border);
 }
 
 audio,
@@ -336,7 +336,7 @@ blockquote cite a {
 }
 
 a {
-    color: color(var(--color-primary) l(-5%));
+    color: var(--color-primary);
     text-decoration: none;
     transition: 0.4s ease;
 }

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -18,6 +18,7 @@ production stylesheet in assets/built/screen.css using gulp dev
 @import "components/actions.css";
 @import "components/hamburger.css";
 @import "components/animations.css";
+@import "components/dark-mode.css";
 
 /* Main - Theme styles
 /* ---------------------------------------------------------- */
@@ -84,7 +85,7 @@ body {
   font-size: 1.4rem;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: color(var(--color-base) l(+50%));
+  color: var(--color-secondary);
 }
 
 .error-link {
@@ -106,7 +107,7 @@ body {
 
 .page-head-description {
   margin: 0 0 1.6vw;
-  color: color(var(--color-border) l(-20%));
+  color: var(--color-secondary);
   font-size: 2.2rem;
   line-height: 1.35em;
 }
@@ -119,7 +120,7 @@ body {
 .site-foot {
   margin: 3vw 0 1vw;
   text-align: center;
-  color: color(var(--color-border) l(-20%));
+  color: var(--color-secondary);
   font-size: 1.4rem;
 }
 
@@ -289,7 +290,7 @@ body {
     flex-direction: column;
     justify-content: flex-start;
     height: 40px;
-    background: rgba(255, 255, 255, 0);
+    background: transparent;
     z-index: -1;
     transition: all 0.4s ease-out;
     overflow: hidden;
@@ -349,7 +350,7 @@ body {
   }
 
   .site-head-open {
-    background: rgba(255, 255, 255, 1);
+    background: var(--color-bg);
     transition: background 0.5s ease-out;
     transition-delay: 0.25;
     overflow: hidden;
@@ -620,11 +621,11 @@ body {
   margin: 1.5em 0 3em;
   padding: 20px;
   max-width: 100%;
-  border: color(var(--color-base) l(-10%)) 1px solid;
+  border: #000 1px solid;
   color: var(--color-bg);
   font-size: 1.4rem;
   line-height: 1.5em;
-  background: color(var(--color-base) l(-3%));
+  background: #0d0d0d;
   border-radius: 5px;
 }
 
@@ -671,7 +672,7 @@ body {
   justify-content: center;
   align-items: center;
   margin-bottom: 10px;
-  color: color(var(--color-border) l(-20%));
+  color: var(--color-secondary);
 }
 
 .author-links {

--- a/src/utils/css/vars.css
+++ b/src/utils/css/vars.css
@@ -10,6 +10,7 @@
     --color-base: #131313;
     --color-border: #ddd;
     --color-bg: #f8f8f8;
+    --color-secondary: #ababab;
 
     /* Fonts */
     --font-sans-serif: 'Muli', sans-serif;
@@ -32,4 +33,14 @@
     --margin: 2rem;
     --radius: 0.5rem;
 
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-primary: #5cc4f8;
+        --color-base: #dadada;
+        --color-border: #555;
+        --color-bg: #1a1a1a;
+        --color-secondary: #888;
+    }
 }


### PR DESCRIPTION
Adds automatic dark mode that respects the user's OS preference — no toggle needed.

## What changed

- **`gatsby-config.js`**: Switched `postcss-custom-properties` from `preserve: false` to `preserve: true` so CSS variables survive as runtime properties and can be overridden by media queries. Previously they were compiled away at build time, making runtime theming impossible.
- **`vars.css`**: Added a `--color-secondary` variable (for muted/secondary text) and a `@media (prefers-color-scheme: dark)` block that overrides all four core palette variables plus `--color-secondary`.
- **`global.css` / `screen.css` / `buttons.css`**: Replaced invalid `color(var(--color-base) l(+20%))` style calls throughout — there's no PostCSS color-function plugin installed, so those were silently ignored by browsers. Replaced with `var()` references or explicit values.
- **`screen.css`**: Replaced hardcoded `rgba(255,255,255,...)` mobile nav overlay backgrounds with `transparent` / `var(--color-bg)` so they adapt to dark mode.
- **`dark-mode.css`** (new): Additional overrides that can't be handled via CSS variables alone — `::selection`, `mark`, code blocks, mobile nav overlay, and the post-card counter number.

## Dark palette

| Variable | Light | Dark |
|---|---|---|
| `--color-primary` | `#3eb0ef` | `#5cc4f8` (slightly brighter for dark bg) |
| `--color-base` | `#131313` | `#dadada` |
| `--color-border` | `#ddd` | `#555` |
| `--color-bg` | `#f8f8f8` | `#1a1a1a` |
| `--color-secondary` | `#ababab` | `#888` |

https://claude.ai/code/session_015GJdjoSHPqVY6ijChcyJrC

---
_Generated by [Claude Code](https://claude.ai/code/session_015GJdjoSHPqVY6ijChcyJrC)_