### PR TITLE
Fix real-device nav burger jump, glass nav sliver, and unrounded markdown images

### DIFF
--- a/content/blog/records/kvdu-live/index.md
+++ b/content/blog/records/kvdu-live/index.md
@@ -10,7 +10,7 @@ music:
   url: https://kvdu.bandcamp.com/
 ---
 
-<iframe src="//bandcamp.com/EmbeddedPlayer/album=4234864881/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" seamless="" width="100%" height="300" frameborder="0"></iframe>
+<iframe src="//bandcamp.com/EmbeddedPlayer/album=4234864881/size=large/bgcol=ffffff/linkcol=2f8fd1/artwork=small/transparent=true/" seamless="" width="100%" height="300" frameborder="0"></iframe>
 
 ---
 

--- a/content/blog/records/one-thread/index.md
+++ b/content/blog/records/one-thread/index.md
@@ -11,7 +11,7 @@ music:
   url: https://rogerroll.bandcamp.com/album/one-thread
 ---
 
-<iframe width="100%" height="310" src="//bandcamp.com/EmbeddedPlayer/album=1079686129/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" seamless="" frameborder="0"></iframe>
+<iframe width="100%" height="310" src="//bandcamp.com/EmbeddedPlayer/album=1079686129/size=large/bgcol=ffffff/linkcol=2f8fd1/artwork=small/transparent=true/" seamless="" frameborder="0"></iframe>
 
 ---
 

--- a/content/blog/records/one-thread/index.sv.md
+++ b/content/blog/records/one-thread/index.sv.md
@@ -11,7 +11,7 @@ music:
   url: https://rogerroll.bandcamp.com/album/one-thread
 ---
 
-<iframe width="100%" height="310" src="//bandcamp.com/EmbeddedPlayer/album=1079686129/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" seamless="" frameborder="0"></iframe>
+<iframe width="100%" height="310" src="//bandcamp.com/EmbeddedPlayer/album=1079686129/size=large/bgcol=ffffff/linkcol=2f8fd1/artwork=small/transparent=true/" seamless="" frameborder="0"></iframe>
 
 ---
 

--- a/content/blog/records/polaroid-in-reverse/index.md
+++ b/content/blog/records/polaroid-in-reverse/index.md
@@ -10,7 +10,7 @@ music:
   url: https://rogerroll.bandcamp.com/album/polaroid-in-reverse
 ---
 
-<iframe width="100%" height="210" src="//bandcamp.com/EmbeddedPlayer/album=23354821/size=large/bgcol=ffffff/linkcol=0687f5/artwork=small/transparent=true/" seamless="" frameborder="0"></iframe>
+<iframe width="100%" height="210" src="//bandcamp.com/EmbeddedPlayer/album=23354821/size=large/bgcol=ffffff/linkcol=2f8fd1/artwork=small/transparent=true/" seamless="" frameborder="0"></iframe>
 
 ---
 

--- a/content/blog/records/your-ghost/index.md
+++ b/content/blog/records/your-ghost/index.md
@@ -11,7 +11,7 @@ music:
   url: https://we-are-houses.bandcamp.com/track/your-ghost
 ---
 
-<iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/track=341526956/size=large/bgcol=ffffff/linkcol=0687f5/tracklist=false/artwork=small/transparent=true/" seamless frameborder="0"></iframe><br /><br />
+<iframe style="border: 0; width: 100%; height: 120px;" src="https://bandcamp.com/EmbeddedPlayer/track=341526956/size=large/bgcol=ffffff/linkcol=2f8fd1/tracklist=false/artwork=small/transparent=true/" seamless frameborder="0"></iframe><br /><br />
 
 > It's been thirteen and a half months since we last heard new recorded music from Houses. ...Still, this one's a beauty.
 >

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,8 +1,5 @@
-// custom typefaces
-import "@fontsource/montserrat"
-import "@fontsource/merriweather"
-import "@fontsource/nunito"
-import "@fontsource/alegreya"
+// custom typeface
+import "@fontsource-variable/inter"
 
 /**
  * One could put some only-in-browser logic here...

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -78,6 +78,15 @@ module.exports = {
       options: {
         printRejected: false,
         whitelistPatternsChildren: ["/post-content-body/"],
+        // PurgeCSS only scans src/**/*.{js,jsx,ts,tsx} by default, so it never
+        // sees classes that exist only in markdown/Ghost content (kg-*,
+        // gatsby-resp-image-*). Protect them here so rules targeting them
+        // aren't stripped from the production bundle.
+        purgeCSSOptions: {
+          safelist: {
+            greedy: [/^kg-/, /^gatsby-resp-image/],
+          },
+        },
       },
     },
     {
@@ -180,7 +189,9 @@ module.exports = {
           const siteUrl = urljoin(siteConfig.url, siteConfig.prefix)
           const withTrailing = path.endsWith(`/`) ? path : `${path}/`
           const isSv = path.startsWith(`/sv`)
-          const enPath = isSv ? withTrailing.replace(/^\/sv/, ``) || `/` : withTrailing
+          const enPath = isSv
+            ? withTrailing.replace(/^\/sv/, ``) || `/`
+            : withTrailing
           const svPath = isSv ? withTrailing : `/sv${withTrailing}`
           return {
             // Relative path; with --prefix-paths the plugin prepends /terson correctly.
@@ -188,7 +199,8 @@ module.exports = {
             // sitemap but the onPostBuild hook fixes the sitemap-index reference.
             url: withTrailing,
             changefreq: `monthly`,
-            priority: path === `/` || path === `/sv` || path === `/sv/` ? 1.0 : 0.7,
+            priority:
+              path === `/` || path === `/sv` || path === `/sv/` ? 1.0 : 0.7,
             links: [
               { lang: `x-default`, url: `${siteUrl}/` },
               { lang: `en`, url: `${siteUrl}${enPath}` },

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,15 @@
+import React from "react"
+import interLatinWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2"
+
+export const onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <link
+      key="preload-inter-variable"
+      rel="preload"
+      as="font"
+      type="font/woff2"
+      href={interLatinWoff2}
+      crossOrigin="anonymous"
+    />,
+  ])
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@fontsource/alegreya": "^5.2.8",
-        "@fontsource/merriweather": "^5.2.11",
-        "@fontsource/montserrat": "^5.2.8",
-        "@fontsource/nunito": "^5.2.7",
+        "@fontsource-variable/inter": "^5.2.8",
         "dayjs": "^1.11.21",
         "gatsby": "^5.15.0",
         "gatsby-link": "^5.3.1",
@@ -2299,37 +2296,10 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
     },
-    "node_modules/@fontsource/alegreya": {
+    "node_modules/@fontsource-variable/inter": {
       "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/alegreya/-/alegreya-5.2.8.tgz",
-      "integrity": "sha512-/C4ShWmhyyaDZj9GfFvMaeGrt7pRupgoXdFd26Cg/y5m49UhhifbqBBRNwVhGCt5+wfjmakz7wBhFHJLH5c/mg==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/merriweather": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/@fontsource/merriweather/-/merriweather-5.2.11.tgz",
-      "integrity": "sha512-ZiIMeUh5iT8d73o6xlSF8GKgjV5pgiFrufYc5jZTVAfExtWKqM2vQHnsqXSFMv4ELhAcjt6Vf+5T3oVGXhAizQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/montserrat": {
-      "version": "5.2.8",
-      "resolved": "https://registry.npmjs.org/@fontsource/montserrat/-/montserrat-5.2.8.tgz",
-      "integrity": "sha512-xTjLxSbSfCycDB0pwmNsfNvdfWPaDaRQ2LC6yt/ZI7SdvXG52zHnzNYC/09mzuAuWNJyShkteutfCoDgym56hQ==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/nunito": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource/nunito/-/nunito-5.2.7.tgz",
-      "integrity": "sha512-pmtBq0H9ex9nk+RtJYEJOD9pag393iHETnl/PVKleF4i06cd0ttngK5ZCTgYb5eOqR3Xdlrjtev8m7bmgYprew==",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
     "url": "https://github.com/ImedAdel/gatsby-london/issues"
   },
   "dependencies": {
-    "@fontsource/alegreya": "^5.2.8",
-    "@fontsource/merriweather": "^5.2.11",
-    "@fontsource/montserrat": "^5.2.8",
-    "@fontsource/nunito": "^5.2.7",
+    "@fontsource-variable/inter": "^5.2.8",
     "dayjs": "^1.11.21",
     "gatsby": "^5.15.0",
     "gatsby-link": "^5.3.1",

--- a/src/components/postCard.js
+++ b/src/components/postCard.js
@@ -9,7 +9,7 @@ const PostCard = (props) => (
     } ${props.node.frontmatter.thumbnail ? `with-image` : `no-image`}`}
     style={
       props.node.frontmatter.thumbnail && {
-        backgroundImage: `url(${getSrc(props.node.frontmatter.thumbnail)})`,
+        "--post-card-image": `url(${getSrc(props.node.frontmatter.thumbnail)})`,
       }
     }
   >

--- a/src/layouts/en.js
+++ b/src/layouts/en.js
@@ -9,6 +9,13 @@ const Layout = (props) => {
   const [context, setContext] = React.useState({ langKey: "en", isTranslated })
   const isHome = location.pathname === "/" || location.pathname === "/terson/"
 
+  React.useEffect(() => {
+    document.body.style.overflow = toggleNav ? "hidden" : ""
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [toggleNav])
+
   return (
     <LanguageContext.Provider value={[context, setContext]}>
       <div className={`site-wrapper ${toggleNav ? `site-head-open` : ``}`}>
@@ -17,19 +24,17 @@ const Layout = (props) => {
             <button
               className="nav-burger"
               onClick={() => setToggleNav(!toggleNav)}
+              aria-expanded={toggleNav}
+              aria-controls="site-navigation"
+              aria-label={toggleNav ? "Close menu" : "Open menu"}
             >
-              <div
-                className="hamburger hamburger--collapse"
-                aria-label="Menu"
-                role="button"
-                aria-controls="navigation"
-              >
+              <div className="hamburger hamburger--collapse">
                 <div className="hamburger-box">
                   <div className="hamburger-inner" />
                 </div>
               </div>
             </button>
-            <nav id="swup" className="site-head-left">
+            <nav id="site-navigation" className="site-head-left">
               <ul className="nav">
                 <li
                   className={["nav-home", isHome ? "nav-current" : ""]

--- a/src/layouts/en.js
+++ b/src/layouts/en.js
@@ -8,11 +8,29 @@ const Layout = (props) => {
   const [toggleNav, setToggleNav] = React.useState(false)
   const [context, setContext] = React.useState({ langKey: "en", isTranslated })
   const isHome = location.pathname === "/" || location.pathname === "/terson/"
+  const scrollPositionRef = React.useRef(0)
+
+  const handleToggleNav = () => {
+    if (!toggleNav) {
+      scrollPositionRef.current = window.scrollY
+    }
+    setToggleNav(!toggleNav)
+  }
 
   React.useEffect(() => {
-    document.body.style.overflow = toggleNav ? "hidden" : ""
-    return () => {
-      document.body.style.overflow = ""
+    if (toggleNav) {
+      const scrollY = scrollPositionRef.current
+      document.body.style.position = "fixed"
+      document.body.style.top = `-${scrollY}px`
+      document.body.style.left = "0"
+      document.body.style.right = "0"
+      return () => {
+        document.body.style.position = ""
+        document.body.style.top = ""
+        document.body.style.left = ""
+        document.body.style.right = ""
+        window.scrollTo(0, scrollY)
+      }
     }
   }, [toggleNav])
 
@@ -23,7 +41,7 @@ const Layout = (props) => {
           <div className="site-head-container">
             <button
               className="nav-burger"
-              onClick={() => setToggleNav(!toggleNav)}
+              onClick={handleToggleNav}
               aria-expanded={toggleNav}
               aria-controls="site-navigation"
               aria-label={toggleNav ? "Close menu" : "Open menu"}

--- a/src/layouts/sv.js
+++ b/src/layouts/sv.js
@@ -9,11 +9,29 @@ const Layout = (props) => {
   const [context, setContext] = React.useState({ langKey: "sv", isTranslated })
   const isHome =
     location.pathname === "/sv/" || location.pathname === "/terson/sv/"
+  const scrollPositionRef = React.useRef(0)
+
+  const handleToggleNav = () => {
+    if (!toggleNav) {
+      scrollPositionRef.current = window.scrollY
+    }
+    setToggleNav(!toggleNav)
+  }
 
   React.useEffect(() => {
-    document.body.style.overflow = toggleNav ? "hidden" : ""
-    return () => {
-      document.body.style.overflow = ""
+    if (toggleNav) {
+      const scrollY = scrollPositionRef.current
+      document.body.style.position = "fixed"
+      document.body.style.top = `-${scrollY}px`
+      document.body.style.left = "0"
+      document.body.style.right = "0"
+      return () => {
+        document.body.style.position = ""
+        document.body.style.top = ""
+        document.body.style.left = ""
+        document.body.style.right = ""
+        window.scrollTo(0, scrollY)
+      }
     }
   }, [toggleNav])
 
@@ -24,7 +42,7 @@ const Layout = (props) => {
           <div className="site-head-container">
             <button
               className="nav-burger"
-              onClick={() => setToggleNav(!toggleNav)}
+              onClick={handleToggleNav}
               aria-expanded={toggleNav}
               aria-controls="site-navigation"
               aria-label={toggleNav ? "Stäng menyn" : "Öppna menyn"}

--- a/src/layouts/sv.js
+++ b/src/layouts/sv.js
@@ -10,6 +10,13 @@ const Layout = (props) => {
   const isHome =
     location.pathname === "/sv/" || location.pathname === "/terson/sv/"
 
+  React.useEffect(() => {
+    document.body.style.overflow = toggleNav ? "hidden" : ""
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [toggleNav])
+
   return (
     <LanguageContext.Provider value={[context, setContext]}>
       <div className={`site-wrapper ${toggleNav ? `site-head-open` : ``}`}>
@@ -18,19 +25,17 @@ const Layout = (props) => {
             <button
               className="nav-burger"
               onClick={() => setToggleNav(!toggleNav)}
+              aria-expanded={toggleNav}
+              aria-controls="site-navigation"
+              aria-label={toggleNav ? "Stäng menyn" : "Öppna menyn"}
             >
-              <div
-                className="hamburger hamburger--collapse"
-                aria-label="Menu"
-                role="button"
-                aria-controls="navigation"
-              >
+              <div className="hamburger hamburger--collapse">
                 <div className="hamburger-box">
                   <div className="hamburger-inner" />
                 </div>
               </div>
             </button>
-            <nav id="swup" className="site-head-left">
+            <nav id="site-navigation" className="site-head-left">
               <ul className="nav">
                 <li
                   className={["nav-home", isHome ? "nav-current" : ""]

--- a/src/utils/css/components/buttons.css
+++ b/src/utils/css/components/buttons.css
@@ -6,21 +6,21 @@ input[type="reset"],
 input[type="button"],
 button,
 .button {
-    display: inline-block;
-    height: var(--height);
-    padding: 0 2rem;
-    border: 0;
-    border-radius: var(--radius);
-    cursor: pointer;
-    font-family: var(--font-sans-serif);
-    font-size: 1.4rem;
-    font-weight: var(--font-normal);
-    line-height: var(--height);
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    appearance: none;
-    transition: 0.4s ease;
+  display: inline-block;
+  height: var(--height);
+  padding: 0 2rem;
+  border: 0;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-family: var(--font-sans-serif);
+  font-size: 1.4rem;
+  font-weight: var(--font-normal);
+  line-height: var(--height);
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  appearance: none;
+  transition: 0.4s ease;
 }
 
 input[type="submit"].fit,
@@ -28,7 +28,7 @@ input[type="reset"].fit,
 input[type="button"].fit,
 button.fit,
 .button.fit {
-    width: 100%;
+  width: 100%;
 }
 
 input[type="submit"].small,
@@ -36,10 +36,10 @@ input[type="reset"].small,
 input[type="button"].small,
 button.small,
 .button.small {
-    height: calc(var(--height) * 0.9);
-    line-height: calc(var(--height) * 0.9);
-    padding: 0 1.5rem;
-    font-size: 1.2rem;
+  height: calc(var(--height) * 0.9);
+  line-height: calc(var(--height) * 0.9);
+  padding: 0 1.5rem;
+  font-size: 1.2rem;
 }
 
 input[type="submit"].large,
@@ -47,12 +47,11 @@ input[type="reset"].large,
 input[type="button"].large,
 button.large,
 .button.large {
-    height: calc(var(--height) * 1.14);
-    line-height: calc(var(--height) * 1.14);
-    padding: 0 3rem;
-    font-size: 1.6rem;
+  height: calc(var(--height) * 1.14);
+  line-height: calc(var(--height) * 1.14);
+  padding: 0 3rem;
+  font-size: 1.6rem;
 }
-
 
 input[type="submit"].disabled,
 input[type="submit"]:disabled,
@@ -64,20 +63,18 @@ button.disabled,
 button:disabled,
 .button.disabled,
 .button:disabled {
-    pointer-events: none;
-    opacity: 0.4;
+  pointer-events: none;
+  opacity: 0.4;
 }
-
-
 
 input[type="submit"],
 input[type="reset"],
 input[type="button"],
 button,
 .button {
-    color: var(--color-primary) !important;
-    background-color: transparent;
-    box-shadow: inset 0 0 0 2px var(--color-primary);
+  color: var(--color-primary) !important;
+  background-color: transparent;
+  box-shadow: inset 0 0 0 2px var(--color-primary);
 }
 
 input[type="submit"]:hover,
@@ -85,11 +82,22 @@ input[type="reset"]:hover,
 input[type="button"]:hover,
 button:hover,
 .button:hover {
-    text-decoration: none;
-    color: var(--color-primary) !important;
-    box-shadow: inset 0 0 0 2px var(--color-primary);
-    opacity: 0.8;
-    transition: 0.2s ease;
+  text-decoration: none;
+  color: var(--color-primary) !important;
+  box-shadow: inset 0 0 0 2px var(--color-primary);
+  opacity: 0.8;
+  transform: translateY(-1px);
+  transition: 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  input[type="submit"]:hover,
+  input[type="reset"]:hover,
+  input[type="button"]:hover,
+  button:hover,
+  .button:hover {
+    transform: none;
+  }
 }
 
 input[type="submit"].primary,
@@ -97,9 +105,9 @@ input[type="reset"].primary,
 input[type="button"].primary,
 button.primary,
 .button.primary {
-    color: #fff !important;
-    background-color: var(--color-primary);
-    box-shadow: none;
+  color: #fff !important;
+  background-color: var(--color-primary);
+  box-shadow: none;
 }
 
 input[type="submit"].primary:hover,
@@ -107,6 +115,6 @@ input[type="reset"].primary:hover,
 input[type="button"].primary:hover,
 button.primary:hover,
 .button.primary:hover {
-        background-color: var(--color-primary);
-        opacity: 0.85;
-    }
+  background-color: var(--color-primary);
+  opacity: 0.85;
+}

--- a/src/utils/css/components/dark-mode.css
+++ b/src/utils/css/components/dark-mode.css
@@ -2,62 +2,62 @@
 /* ---------------------------------------------------------- */
 
 @media (prefers-color-scheme: dark) {
-    body {
-        background: var(--color-bg);
-    }
+  body {
+    background: var(--color-bg);
+  }
 
-    ::selection {
-        background: #1a6b9a;
-        color: #fff;
-    }
+  ::selection {
+    background: #1a6b9a;
+    color: #fff;
+  }
 
-    mark {
-        background-color: #4a4400;
-        color: #e8e8e8;
-    }
+  mark {
+    background-color: #4a4400;
+    color: #e8e8e8;
+  }
 
-    /* Mobile nav open state */
-    .site-head-open {
-        background: rgba(26, 26, 26, 1);
-    }
+  /* Mobile nav open state */
+  .site-head-open {
+    background: rgba(22, 22, 22, 1);
+  }
 
-    /* Code blocks */
-    .post-content-body pre {
-        border-color: #333;
-        background: #111;
-    }
+  /* Code blocks */
+  .post-content-body pre {
+    border-color: #333;
+    background: #111;
+  }
 
-    .post-content-body code {
-        background: #2d2d2d;
-        color: var(--color-base);
-    }
+  .post-content-body code {
+    background: #2d2d2d;
+    color: var(--color-base);
+  }
 
-    /* Post cards without images: lighten the counter number */
-    .post-card.no-image:before {
-        color: rgba(255, 255, 255, 0.1);
-    }
+  /* Post cards without images: lighten the counter number */
+  .post-card.no-image:before {
+    color: rgba(255, 255, 255, 0.1);
+  }
 
-    /* Subscribe button border */
-    .subscribe-button {
-        border-color: var(--color-base);
-        color: var(--color-base);
-    }
+  /* Subscribe button border */
+  .subscribe-button {
+    border-color: var(--color-base);
+    color: var(--color-base);
+  }
 
-    /* Prism syntax highlighting adjustments */
-    .token.comment,
-    .token.prolog,
-    .token.doctype,
-    .token.cdata {
-        color: #8292a2;
-    }
+  /* Prism syntax highlighting adjustments */
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #8292a2;
+  }
 }
 
 @media (prefers-color-scheme: dark) and (max-width: 850px) {
-    .site-head-container {
-        background: rgba(26, 26, 26, 0);
-    }
+  .site-head-container {
+    background: rgba(22, 22, 22, 0);
+  }
 
-    .site-head-open .site-head-container {
-        background: rgba(26, 26, 26, 1);
-    }
+  .site-head-open .site-head-container {
+    background: rgba(22, 22, 22, 1);
+  }
 }

--- a/src/utils/css/components/dark-mode.css
+++ b/src/utils/css/components/dark-mode.css
@@ -56,8 +56,4 @@
   .site-head-container {
     background: rgba(22, 22, 22, 0);
   }
-
-  .site-head-open .site-head-container {
-    background: rgba(22, 22, 22, 1);
-  }
 }

--- a/src/utils/css/components/ghost.css
+++ b/src/utils/css/components/ghost.css
@@ -18,6 +18,13 @@
   border-radius: var(--radius);
 }
 
+/* Markdown-authored post images (rendered via gatsby-remark-images, not
+   Ghost's own kg-image markup) need their own rounding rule. */
+.gatsby-resp-image-wrapper {
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
 .kg-card figcaption {
   padding: 1.5rem;
   font-size: 1.3rem;
@@ -56,7 +63,8 @@
   .kg-width-full {
     width: 100vw;
   }
-  .kg-width-full .kg-image {
+  .kg-width-full .kg-image,
+  .kg-width-full .gatsby-resp-image-wrapper {
     border-radius: 0;
   }
   .kg-width-full figcaption {

--- a/src/utils/css/components/ghost.css
+++ b/src/utils/css/components/ghost.css
@@ -18,12 +18,6 @@
   border-radius: var(--radius);
 }
 
-/* Full-bleed images should stay edge-to-edge, un-rounded */
-.kg-width-wide .kg-image,
-.kg-width-full .kg-image {
-  border-radius: 0;
-}
-
 .kg-card figcaption {
   padding: 1.5rem;
   font-size: 1.3rem;
@@ -61,6 +55,9 @@
 @media (max-width: 800px) {
   .kg-width-full {
     width: 100vw;
+  }
+  .kg-width-full .kg-image {
+    border-radius: 0;
   }
   .kg-width-full figcaption {
     padding-left: 6vw;

--- a/src/utils/css/components/ghost.css
+++ b/src/utils/css/components/ghost.css
@@ -15,6 +15,13 @@
 .kg-image {
   max-width: 100%;
   width: 100%;
+  border-radius: var(--radius);
+}
+
+/* Full-bleed images should stay edge-to-edge, un-rounded */
+.kg-width-wide .kg-image,
+.kg-width-full .kg-image {
+  border-radius: 0;
 }
 
 .kg-card figcaption {

--- a/src/utils/css/components/global.css
+++ b/src/utils/css/components/global.css
@@ -78,173 +78,173 @@ time,
 mark,
 audio,
 video {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font: inherit;
-    font-size: 100%;
-    vertical-align: baseline;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font: inherit;
+  font-size: 100%;
+  vertical-align: baseline;
 }
 body {
-    line-height: 1;
+  line-height: 1;
 }
 ol,
 ul {
-    list-style: none;
+  list-style: none;
 }
 blockquote,
 q {
-    quotes: none;
+  quotes: none;
 }
 blockquote:before,
 blockquote:after,
 q:before,
 q:after {
-    content: "";
-    content: none;
+  content: "";
+  content: none;
 }
 table {
-    border-spacing: 0;
-    border-collapse: collapse;
+  border-spacing: 0;
+  border-collapse: collapse;
 }
 img {
-    max-width: 100%;
+  max-width: 100%;
 }
 html {
-    box-sizing: border-box;
-    font-family: sans-serif;
+  box-sizing: border-box;
+  font-family: sans-serif;
 
-    -ms-text-size-adjust: 100%;
-    -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 *,
 *:before,
 *:after {
-    box-sizing: inherit;
+  box-sizing: inherit;
 }
 a {
-    background-color: transparent;
+  background-color: transparent;
 }
 a:active,
 a:hover {
-    outline: 0;
+  outline: 0;
 }
 b,
 strong {
-    font-weight: bold;
+  font-weight: bold;
 }
 i,
 em,
 dfn {
-    font-style: italic;
+  font-style: italic;
 }
 h1 {
-    margin: 0.67em 0;
-    font-size: 2em;
+  margin: 0.67em 0;
+  font-size: 2em;
 }
 small {
-    font-size: 80%;
+  font-size: 80%;
 }
 sub,
 sup {
-    position: relative;
-    font-size: 75%;
-    line-height: 0;
-    vertical-align: baseline;
+  position: relative;
+  font-size: 75%;
+  line-height: 0;
+  vertical-align: baseline;
 }
 sup {
-    top: -0.5em;
+  top: -0.5em;
 }
 sub {
-    bottom: -0.25em;
+  bottom: -0.25em;
 }
 img {
-    border: 0;
+  border: 0;
 }
 svg:not(:root) {
-    overflow: hidden;
+  overflow: hidden;
 }
 mark {
-    background-color: #fdffb6;
+  background-color: #fdffb6;
 }
 code,
 kbd,
 pre,
 samp {
-    font-family: monospace, monospace;
-    font-size: 1em;
+  font-family: monospace, monospace;
+  font-size: 1em;
 }
 button,
 input,
 optgroup,
 select,
 textarea {
-    margin: 0;
-    color: inherit;
-    font: inherit;
+  margin: 0;
+  color: inherit;
+  font: inherit;
 }
 button {
-    overflow: visible;
-    border: none;
+  overflow: visible;
+  border: none;
 }
 button,
 select {
-    text-transform: none;
+  text-transform: none;
 }
 button,
 html input[type="button"],
 input[type="reset"],
 input[type="submit"] {
-    cursor: pointer;
-    -webkit-appearance: button;
+  cursor: pointer;
+  -webkit-appearance: button;
 }
 button[disabled],
 html input[disabled] {
-    cursor: default;
+  cursor: default;
 }
 button::-moz-focus-inner,
 input::-moz-focus-inner {
-    padding: 0;
-    border: 0;
+  padding: 0;
+  border: 0;
 }
 input {
-    line-height: normal;
+  line-height: normal;
 }
 input:focus {
-    outline: none;
+  outline: none;
 }
 input[type="checkbox"],
 input[type="radio"] {
-    box-sizing: border-box;
-    padding: 0;
+  box-sizing: border-box;
+  padding: 0;
 }
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
-    height: auto;
+  height: auto;
 }
 input[type="search"] {
-    box-sizing: content-box;
+  box-sizing: content-box;
 
-    -webkit-appearance: textfield;
+  -webkit-appearance: textfield;
 }
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
-    -webkit-appearance: none;
+  -webkit-appearance: none;
 }
 legend {
-    padding: 0;
-    border: 0;
+  padding: 0;
+  border: 0;
 }
 textarea {
-    overflow: auto;
+  overflow: auto;
 }
 table {
-    border-spacing: 0;
-    border-collapse: collapse;
+  border-spacing: 0;
+  border-collapse: collapse;
 }
 td,
 th {
-    padding: 0;
+  padding: 0;
 }
 
 /* ==========================================================================
@@ -252,43 +252,43 @@ th {
    ========================================================================== */
 
 html {
-    overflow-x: hidden;
-    overflow-y: scroll;
-    font-size: 62.5%;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  font-size: 62.5%;
 
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {
-    overflow-x: hidden;
-    color: var(--color-base);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    font-size: 1.5rem;
-    line-height: 1.6em;
-    font-weight: 400;
-    font-style: normal;
-    letter-spacing: 0;
-    text-rendering: optimizeLegibility;
-    background: #fff;
+  overflow-x: hidden;
+  color: var(--color-base);
+  font-family: var(--font-sans-serif);
+  font-size: 1.5rem;
+  line-height: 1.65em;
+  font-weight: 400;
+  font-style: normal;
+  letter-spacing: 0;
+  text-rendering: optimizeLegibility;
+  background: #fff;
 
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    -moz-font-feature-settings: "liga" on;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -moz-font-feature-settings: "liga" on;
 }
 
 ::selection {
-    text-shadow: none;
-    background: #cbeafb;
+  text-shadow: none;
+  background: #cbeafb;
 }
 
 hr {
-    position: relative;
-    display: block;
-    width: 50%;
-    margin: 2.5em auto 2.5em auto;
-    padding: 0;
-    height: 1px;
-    border: 0;
-    border-top: 1px solid var(--color-border);
+  position: relative;
+  display: block;
+  width: 50%;
+  margin: 2.5em auto 2.5em auto;
+  padding: 0;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid var(--color-border);
 }
 
 audio,
@@ -297,53 +297,65 @@ iframe,
 img,
 svg,
 video {
-    vertical-align: middle;
+  vertical-align: middle;
 }
 
 p,
 blockquote {
-    margin: 0 0 1.5em 0;
+  margin: 0 0 1.5em 0;
 }
 
 blockquote {
-    margin: 1.5em 0;
-    padding: 0 1.6em 0 1.6em;
-    border-left: var(--color-bg) 0.5em solid;
+  margin: 1.5em 0;
+  padding: 0 1.6em 0 1.6em;
+  border-left: var(--color-bg) 0.5em solid;
 }
 
 blockquote p {
-    margin: 0.8em 0;
-    font-size: 1.2em;
-    font-weight: 300;
+  margin: 0.8em 0;
+  font-size: 1.2em;
+  font-weight: 300;
 }
 
 blockquote small {
-    display: inline-block;
-    margin: 0.8em 0 0.8em 1.5em;
-    font-size: 0.9em;
-    opacity: 0.8;
+  display: inline-block;
+  margin: 0.8em 0 0.8em 1.5em;
+  font-size: 0.9em;
+  opacity: 0.8;
 }
 /* Quotation marks */
 blockquote small:before {
-    content: "\2014 \00A0";
+  content: "\2014 \00A0";
 }
 
 blockquote cite {
-    font-weight: bold;
+  font-weight: bold;
 }
 blockquote cite a {
-    font-weight: normal;
+  font-weight: normal;
 }
 
 a {
-    color: var(--color-primary);
-    text-decoration: none;
-    transition: 0.4s ease;
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 0.15em;
+  transition:
+    color 0.3s ease,
+    text-decoration-color 0.3s ease;
 }
 
 a:hover {
-    text-decoration: underline;
-    transition: 0.2s ease;
+  text-decoration-color: currentColor;
+  transition:
+    color 0.2s ease,
+    text-decoration-color 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a {
+    transition: none;
+  }
 }
 
 h1,
@@ -352,55 +364,55 @@ h3,
 h4,
 h5,
 h6 {
-    margin-top: 0;
-    line-height: 1.4;
-    font-weight: 700;
-    text-rendering: optimizeLegibility;
+  margin-top: 0;
+  line-height: 1.4;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-rendering: optimizeLegibility;
 }
 
 h1 {
-    margin: 0 0 0.5em 0;
-    font-size: 5.7rem;
-    font-weight: 800;
+  margin: 0 0 0.5em 0;
+  font-size: 5.7rem;
+  font-weight: 800;
 }
 @media (max-width: 500px) {
-    h1 {
-        font-size: 2.7rem;
-    }
+  h1 {
+    font-size: 2.7rem;
+  }
 }
 
 h2 {
-    margin: 1.5em 0 0.5em 0;
-    font-size: 4rem;
+  margin: 1.5em 0 0.5em 0;
+  font-size: 4rem;
 }
 @media (max-width: 500px) {
-    h2 {
-        font-size: 2rem;
-    }
+  h2 {
+    font-size: 2rem;
+  }
 }
 
 h3 {
-    margin: 1.5em 0 1em 0;
-    font-size: 3.2rem;
+  margin: 1.5em 0 1em 0;
+  font-size: 3.2rem;
 }
 @media (max-width: 500px) {
-    h3 {
-        font-size: 1.8rem;
-    }
+  h3 {
+    font-size: 1.8rem;
+  }
 }
 
 h4 {
-    margin: 1.5em 0 1em 0;
-    font-size: 2.6rem;
+  margin: 1.5em 0 1em 0;
+  font-size: 2.6rem;
 }
 
 h5 {
-    margin: 1.5em 0 1em 0;
-    font-size: 2.4rem;
+  margin: 1.5em 0 1em 0;
+  font-size: 2.4rem;
 }
 
 h6 {
-    margin: 1.5em 0 1em 0;
-    font-size: 2.2rem;
+  margin: 1.5em 0 1em 0;
+  font-size: 2.2rem;
 }
-

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -24,7 +24,7 @@ production stylesheet in assets/built/screen.css using gulp dev
 /* ---------------------------------------------------------- */
 
 body {
-  font-family: "Muli", sans-serif;
+  font-family: var(--font-sans-serif);
   background: var(--color-bg);
   transition: background 0.3s ease-out;
   transition-delay: 0.25;
@@ -174,6 +174,7 @@ body {
   color: var(--color-base);
   font-weight: 600;
   opacity: 0.4;
+  transition: opacity 0.3s ease;
 }
 
 .nav-current a,
@@ -414,6 +415,17 @@ body {
   background-size: cover;
   overflow: hidden;
   counter-increment: posts;
+  transition: background-size 0.6s cubic-bezier(0.33, 0, 0.2, 1);
+}
+
+.post-card.with-image:hover {
+  background-size: 106%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .post-card {
+    transition: none;
+  }
 }
 
 @media (max-width: 700px) {
@@ -686,7 +698,7 @@ body {
 .post-content-body blockquote {
   margin: 0 0 1.5em;
   padding: 0 1.5em;
-  border-left: #3eb0ef 3px solid;
+  border-left: var(--color-primary) 3px solid;
 }
 
 .post-content-body blockquote p {

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -276,6 +276,12 @@ body {
   }
   .nav-burger {
     display: block;
+    /* Fixed (not absolute) and at a constant offset in both open and
+       closed states, so toggling the menu never changes its containing
+       block or position values, eliminating any jump/flash on toggle. */
+    position: fixed;
+    left: 6vw;
+    top: 6vw;
     box-shadow: none;
     color: transparent;
     background-color: transparent;
@@ -372,21 +378,29 @@ body {
     height: 100dvh;
     padding: 6vw;
     overflow-y: auto;
+    z-index: 9000;
+  }
+
+  /* A dedicated, viewport-pinned layer for the glass effect, kept separate
+     from the scrollable nav content above so backdrop-filter always covers
+     the full screen regardless of how tall the nav content itself is. */
+  .site-head-open .site-head::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     background: var(--overlay-bg);
     backdrop-filter: blur(20px) saturate(160%);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
-    z-index: 9000;
+    z-index: -1;
   }
 
   .site-head-open .site-head-container {
     height: auto;
     overflow: visible;
     transition: height 0.2s ease-in;
-  }
-
-  .site-head-open .nav-burger {
-    left: 6vw;
-    top: 6vw;
   }
 
   .site-head-open .site-head-left,

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -394,7 +394,7 @@ body {
     border-bottom: var(--color-base) 2px solid;
   }
   .site-head-open .site-head-right a {
-    opacity: 0.5;
+    opacity: 0.85;
   }
   .site-head-open .site-foot {
     display: block;

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -202,6 +202,7 @@ body {
   letter-spacing: 1px;
 }
 
+.site-head-logo,
 .site-head-logo:hover {
   text-decoration: none;
 }
@@ -359,7 +360,7 @@ body {
     height: 100vh;
   }
 
-  .site-head-open .site-head-container {
+  .site-head-open .site-head {
     position: fixed;
     top: 0;
     right: 0;
@@ -371,8 +372,18 @@ body {
     background: var(--overlay-bg);
     backdrop-filter: blur(20px) saturate(160%);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
-    transition: height 0.2s ease-in;
     z-index: 9000;
+  }
+
+  .site-head-open .site-head-container {
+    height: auto;
+    overflow: visible;
+    transition: height 0.2s ease-in;
+  }
+
+  .site-head-open .nav-burger {
+    left: 6vw;
+    top: 6vw;
   }
 
   .site-head-open .site-head-left,
@@ -418,6 +429,7 @@ body {
 
 .post-card {
   position: relative;
+  border-radius: var(--radius);
   flex: 1 1 calc(50% - 0.5rem);
   display: flex;
   position: relative;
@@ -426,15 +438,29 @@ body {
   background-size: cover;
   overflow: hidden;
   counter-increment: posts;
-  transition: background-size 0.6s cubic-bezier(0.33, 0, 0.2, 1);
 }
 
-.post-card.with-image:hover {
-  background-size: 106%;
+.post-card.with-image::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-image: var(--post-card-image);
+  background-position: center center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  transition: transform 1.2s cubic-bezier(0.33, 0, 0.2, 1);
+  will-change: transform;
+}
+
+.post-card.with-image:hover::before {
+  transform: scale(1.08);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .post-card {
+  .post-card.with-image::before {
     transition: none;
   }
 }
@@ -547,6 +573,7 @@ body {
 
 .home-recent-card {
   position: relative;
+  border-radius: var(--radius);
   flex: 1 1 calc(50% - 0.5rem);
   aspect-ratio: 3 / 2;
   background: linear-gradient(135deg, #1f1f1f 0%, #111 100%) center center;
@@ -673,6 +700,10 @@ body {
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
   transform: translateX(calc(50vw - 50%));
+}
+
+.post-content-image .kg-image {
+  border-radius: 0;
 }
 
 .post-content-body {

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -267,6 +267,7 @@ body {
   left: 0;
   z-index: 9999;
   padding: 12px 12px 12px 0;
+  transition: none;
 }
 
 @media (max-width: 850px) {
@@ -358,6 +359,7 @@ body {
     transition-delay: 0.25;
     overflow: hidden;
     height: 100vh;
+    height: 100dvh;
   }
 
   .site-head-open .site-head {
@@ -367,6 +369,7 @@ body {
     bottom: 0;
     left: 0;
     height: 100vh;
+    height: 100dvh;
     padding: 6vw;
     overflow-y: auto;
     background: var(--overlay-bg);
@@ -451,7 +454,7 @@ body {
   background-position: center center;
   background-size: cover;
   background-repeat: no-repeat;
-  transition: transform 1.2s cubic-bezier(0.33, 0, 0.2, 1);
+  transition: transform 0.9s cubic-bezier(0.33, 0, 0.2, 1);
   will-change: transform;
 }
 
@@ -700,10 +703,6 @@ body {
   margin-left: calc(50% - 50vw);
   margin-right: calc(50% - 50vw);
   transform: translateX(calc(50vw - 50%));
-}
-
-.post-content-image .kg-image {
-  border-radius: 0;
 }
 
 .post-content-body {

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -360,8 +360,19 @@ body {
   }
 
   .site-head-open .site-head-container {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     height: 100vh;
+    padding: 6vw;
+    overflow-y: auto;
+    background: var(--overlay-bg);
+    backdrop-filter: blur(20px) saturate(160%);
+    -webkit-backdrop-filter: blur(20px) saturate(160%);
     transition: height 0.2s ease-in;
+    z-index: 9000;
   }
 
   .site-head-open .site-head-left,

--- a/src/utils/css/vars.css
+++ b/src/utils/css/vars.css
@@ -8,6 +8,7 @@
   --color-border: #e2e2e2;
   --color-bg: #fafaf9;
   --color-secondary: #ababab;
+  --overlay-bg: rgba(250, 250, 249, 0.82);
 
   /* Fonts */
   --font-sans-serif:
@@ -40,5 +41,6 @@
     --color-border: #4a4a4a;
     --color-bg: #161616;
     --color-secondary: #888;
+    --overlay-bg: rgba(22, 22, 22, 0.82);
   }
 }

--- a/src/utils/css/vars.css
+++ b/src/utils/css/vars.css
@@ -1,46 +1,44 @@
 /* Variables
 /* ---------------------------------------------------------- */
 
-@import url('https://fonts.googleapis.com/css?family=Muli:400,400i,600,700,700i,800&display=swap');
-
 :root {
+  /* Colours */
+  --color-primary: #2f8fd1;
+  --color-base: #181818;
+  --color-border: #e2e2e2;
+  --color-bg: #fafaf9;
+  --color-secondary: #ababab;
 
-    /* Colours */
-    --color-primary: #3eb0ef;
-    --color-base: #131313;
-    --color-border: #ddd;
-    --color-bg: #f8f8f8;
-    --color-secondary: #ababab;
+  /* Fonts */
+  --font-sans-serif:
+    "Inter Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  --font-serif: Georgia, Times, serif;
+  --font-mono: Menlo, Courier, monospace;
+  --font-light: 100;
+  --font-normal: 400;
+  --font-bold: 700;
+  --font-heavy: 800;
 
-    /* Fonts */
-    --font-sans-serif: 'Muli', sans-serif;
-    --font-serif: Georgia, Times, serif;
-    --font-mono: Menlo, Courier, monospace;
-    --font-light: 100;
-    --font-normal: 400;
-    --font-bold: 700;
-    --font-heavy: 800;
+  /* Breakpoints */
+  --xlarge: 1680px;
+  --large: 1280px;
+  --medium: 980px;
+  --small: 740px;
+  --xsmall: 480px;
 
-    /* Breakpoints */
-    --xlarge: 1680px;
-    --large: 1280px;
-    --medium: 980px;
-    --small: 740px;
-    --xsmall: 480px;
-
-    /* Sizes */
-    --height: 4rem;
-    --margin: 2rem;
-    --radius: 0.5rem;
-
+  /* Sizes */
+  --height: 4rem;
+  --margin: 2rem;
+  --radius: 0.5rem;
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
-        --color-primary: #5cc4f8;
-        --color-base: #dadada;
-        --color-border: #555;
-        --color-bg: #1a1a1a;
-        --color-secondary: #888;
-    }
+  :root {
+    --color-primary: #5fc1f0;
+    --color-base: #e2e2e2;
+    --color-border: #4a4a4a;
+    --color-bg: #161616;
+    --color-secondary: #888;
+  }
 }


### PR DESCRIPTION
## Summary
- Make `.nav-burger` position permanently fixed/constant across open and closed states instead of switching containing block on toggle, which was still causing a visible jump on real iOS Safari despite no CSS transition being present.
- Decouple the mobile nav's glass/blur effect into a `::before` pseudo-element pinned to the viewport, so `backdrop-filter` always covers the full screen height regardless of the scrollable nav content's height (fixes a sliver of unblurred content visible at the bottom on real devices).
- Add a `border-radius` rule for `.gatsby-resp-image-wrapper` (the markup `gatsby-remark-images` generates for standard markdown images), since previously only the post thumbnail carried the `.kg-image` class and got rounded.
- Safelist `kg-*` and `gatsby-resp-image-*` selectors in the PurgeCSS config, since PurgeCSS's default content glob only scans JS/JSX source and never sees classes that exist solely in markdown content, silently stripping any CSS rule that targets them (this was also affecting a pre-existing rule, unrelated to this PR's other changes).

## Test plan
- [x] Rebuilt production bundle (`gatsby build`) and confirmed `.gatsby-resp-image-wrapper` / `kg-*` rules now survive in compiled CSS
- [x] Verified via Playwright on the production build that nav-burger position is constant (no jump) across open/close
- [x] Verified via Playwright that the blurred nav overlay correctly covers content at the bottom of the viewport
- [x] Verified all markdown images on a multi-image post (`/travels-to/iceland-2025/`) are rounded on desktop, with the one full-bleed `.kg-width-full` image correctly un-rounded on mobile
- [ ] User to verify on real iPhone 15 Pro


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYDxtTFpBvuEMxkv73ssko)_