### PR TITLE
Fix real-device nav burger jump, glass nav sliver, and unrounded markdown images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -78,6 +78,15 @@ module.exports = {
       options: {
         printRejected: false,
         whitelistPatternsChildren: ["/post-content-body/"],
+        // PurgeCSS only scans src/**/*.{js,jsx,ts,tsx} by default, so it never
+        // sees classes that exist only in markdown/Ghost content (kg-*,
+        // gatsby-resp-image-*). Protect them here so rules targeting them
+        // aren't stripped from the production bundle.
+        purgeCSSOptions: {
+          safelist: {
+            greedy: [/^kg-/, /^gatsby-resp-image/],
+          },
+        },
       },
     },
     {
@@ -180,7 +189,9 @@ module.exports = {
           const siteUrl = urljoin(siteConfig.url, siteConfig.prefix)
           const withTrailing = path.endsWith(`/`) ? path : `${path}/`
           const isSv = path.startsWith(`/sv`)
-          const enPath = isSv ? withTrailing.replace(/^\/sv/, ``) || `/` : withTrailing
+          const enPath = isSv
+            ? withTrailing.replace(/^\/sv/, ``) || `/`
+            : withTrailing
           const svPath = isSv ? withTrailing : `/sv${withTrailing}`
           return {
             // Relative path; with --prefix-paths the plugin prepends /terson correctly.
@@ -188,7 +199,8 @@ module.exports = {
             // sitemap but the onPostBuild hook fixes the sitemap-index reference.
             url: withTrailing,
             changefreq: `monthly`,
-            priority: path === `/` || path === `/sv` || path === `/sv/` ? 1.0 : 0.7,
+            priority:
+              path === `/` || path === `/sv` || path === `/sv/` ? 1.0 : 0.7,
             links: [
               { lang: `x-default`, url: `${siteUrl}/` },
               { lang: `en`, url: `${siteUrl}${enPath}` },

--- a/src/utils/css/components/ghost.css
+++ b/src/utils/css/components/ghost.css
@@ -18,6 +18,13 @@
   border-radius: var(--radius);
 }
 
+/* Markdown-authored post images (rendered via gatsby-remark-images, not
+   Ghost's own kg-image markup) need their own rounding rule. */
+.gatsby-resp-image-wrapper {
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
 .kg-card figcaption {
   padding: 1.5rem;
   font-size: 1.3rem;
@@ -56,7 +63,8 @@
   .kg-width-full {
     width: 100vw;
   }
-  .kg-width-full .kg-image {
+  .kg-width-full .kg-image,
+  .kg-width-full .gatsby-resp-image-wrapper {
     border-radius: 0;
   }
   .kg-width-full figcaption {

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -276,6 +276,12 @@ body {
   }
   .nav-burger {
     display: block;
+    /* Fixed (not absolute) and at a constant offset in both open and
+       closed states, so toggling the menu never changes its containing
+       block or position values, eliminating any jump/flash on toggle. */
+    position: fixed;
+    left: 6vw;
+    top: 6vw;
     box-shadow: none;
     color: transparent;
     background-color: transparent;
@@ -372,21 +378,29 @@ body {
     height: 100dvh;
     padding: 6vw;
     overflow-y: auto;
+    z-index: 9000;
+  }
+
+  /* A dedicated, viewport-pinned layer for the glass effect, kept separate
+     from the scrollable nav content above so backdrop-filter always covers
+     the full screen regardless of how tall the nav content itself is. */
+  .site-head-open .site-head::before {
+    content: "";
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     background: var(--overlay-bg);
     backdrop-filter: blur(20px) saturate(160%);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
-    z-index: 9000;
+    z-index: -1;
   }
 
   .site-head-open .site-head-container {
     height: auto;
     overflow: visible;
     transition: height 0.2s ease-in;
-  }
-
-  .site-head-open .nav-burger {
-    left: 6vw;
-    top: 6vw;
   }
 
   .site-head-open .site-head-left,


### PR DESCRIPTION
## Summary
- Make `.nav-burger` position permanently fixed/constant across open and closed states instead of switching containing block on toggle, which was still causing a visible jump on real iOS Safari despite no CSS transition being present.
- Decouple the mobile nav's glass/blur effect into a `::before` pseudo-element pinned to the viewport, so `backdrop-filter` always covers the full screen height regardless of the scrollable nav content's height (fixes a sliver of unblurred content visible at the bottom on real devices).
- Add a `border-radius` rule for `.gatsby-resp-image-wrapper` (the markup `gatsby-remark-images` generates for standard markdown images), since previously only the post thumbnail carried the `.kg-image` class and got rounded.
- Safelist `kg-*` and `gatsby-resp-image-*` selectors in the PurgeCSS config, since PurgeCSS's default content glob only scans JS/JSX source and never sees classes that exist solely in markdown content, silently stripping any CSS rule that targets them (this was also affecting a pre-existing rule, unrelated to this PR's other changes).

## Test plan
- [x] Rebuilt production bundle (`gatsby build`) and confirmed `.gatsby-resp-image-wrapper` / `kg-*` rules now survive in compiled CSS
- [x] Verified via Playwright on the production build that nav-burger position is constant (no jump) across open/close
- [x] Verified via Playwright that the blurred nav overlay correctly covers content at the bottom of the viewport
- [x] Verified all markdown images on a multi-image post (`/travels-to/iceland-2025/`) are rounded on desktop, with the one full-bleed `.kg-width-full` image correctly un-rounded on mobile
- [ ] User to verify on real iPhone 15 Pro


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYDxtTFpBvuEMxkv73ssko)_