### PR TITLE
Stop pinning nav burger to viewport so it scrolls away when closed

### DIFF
--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -276,16 +276,22 @@ body {
   }
   .nav-burger {
     display: block;
-    /* Fixed (not absolute) and at a constant offset in both open and
-       closed states, so toggling the menu never changes its containing
-       block or position values, eliminating any jump/flash on toggle. */
-    position: fixed;
-    left: 6vw;
-    top: 6vw;
+    /* Stays absolute (relative to .site-head), so it scrolls away with the
+       page like the rest of the header when closed, rather than floating
+       over content. */
+    top: 0;
     box-shadow: none;
     color: transparent;
     background-color: transparent;
     outline: none;
+  }
+  .site-head-open .nav-burger {
+    /* .site-head itself becomes fixed full-screen on open, so this offset
+       is relative to the viewport at that point. Matching it to where the
+       closed-state offset (0,0) lands once .site-wrapper's 6vw padding is
+       accounted for keeps the button visually anchored across the toggle. */
+    left: 6vw;
+    top: 6vw;
   }
   .nav-burger:focus,
   .nav-burger:hover,


### PR DESCRIPTION
## Summary
- The previous fix for the nav burger's open/close jump (#107) made it `position: fixed`, which eliminated the jump but had the side effect of pinning it to the viewport permanently — so it stayed visible floating over page content while scrolling with the menu closed.
- Reverts to `position: absolute` (relative to `.site-head`) so it scrolls away with the header when closed, like before. The closed `(0, 0)` and open `(6vw, 6vw)` offsets land at the same viewport pixel position once `.site-wrapper`'s own `6vw` padding is accounted for, so toggling the menu still doesn't visibly jump.

## Test plan
- [x] Verified via Playwright that burger x/y position is identical across closed → open → closed (no jump)
- [x] Verified the burger's CSS `position` is `absolute` while closed, and it scrolls off-screen (negative `top`) when the page is scrolled with the menu closed
- [x] Verified the bottom-sliver and markdown-image-rounding fixes from #107 still hold
- [ ] User to verify on real iPhone 15 Pro


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYDxtTFpBvuEMxkv73ssko)_