### PR TITLE
Fade nav burger out on scroll instead of repositioning it

### DIFF
--- a/src/layouts/en.js
+++ b/src/layouts/en.js
@@ -6,6 +6,7 @@ import "../i18n"
 const Layout = (props) => {
   const { title, children, location, isTranslated = false } = props
   const [toggleNav, setToggleNav] = React.useState(false)
+  const [isScrolled, setIsScrolled] = React.useState(false)
   const [context, setContext] = React.useState({ langKey: "en", isTranslated })
   const isHome = location.pathname === "/" || location.pathname === "/terson/"
   const scrollPositionRef = React.useRef(0)
@@ -16,6 +17,12 @@ const Layout = (props) => {
     }
     setToggleNav(!toggleNav)
   }
+
+  React.useEffect(() => {
+    const handleScroll = () => setIsScrolled(window.scrollY > 40)
+    window.addEventListener("scroll", handleScroll, { passive: true })
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
 
   React.useEffect(() => {
     if (toggleNav) {
@@ -40,7 +47,9 @@ const Layout = (props) => {
         <header className="site-head">
           <div className="site-head-container">
             <button
-              className="nav-burger"
+              className={`nav-burger ${
+                !toggleNav && isScrolled ? `nav-burger-hidden` : ``
+              }`}
               onClick={handleToggleNav}
               aria-expanded={toggleNav}
               aria-controls="site-navigation"

--- a/src/layouts/sv.js
+++ b/src/layouts/sv.js
@@ -6,6 +6,7 @@ import "../i18n"
 const Layout = (props) => {
   const { title, children, location, isTranslated = false } = props
   const [toggleNav, setToggleNav] = React.useState(false)
+  const [isScrolled, setIsScrolled] = React.useState(false)
   const [context, setContext] = React.useState({ langKey: "sv", isTranslated })
   const isHome =
     location.pathname === "/sv/" || location.pathname === "/terson/sv/"
@@ -17,6 +18,12 @@ const Layout = (props) => {
     }
     setToggleNav(!toggleNav)
   }
+
+  React.useEffect(() => {
+    const handleScroll = () => setIsScrolled(window.scrollY > 40)
+    window.addEventListener("scroll", handleScroll, { passive: true })
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
 
   React.useEffect(() => {
     if (toggleNav) {
@@ -41,7 +48,9 @@ const Layout = (props) => {
         <header className="site-head">
           <div className="site-head-container">
             <button
-              className="nav-burger"
+              className={`nav-burger ${
+                !toggleNav && isScrolled ? `nav-burger-hidden` : ``
+              }`}
               onClick={handleToggleNav}
               aria-expanded={toggleNav}
               aria-controls="site-navigation"

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -276,22 +276,25 @@ body {
   }
   .nav-burger {
     display: block;
-    /* Stays absolute (relative to .site-head), so it scrolls away with the
-       page like the rest of the header when closed, rather than floating
-       over content. */
-    top: 0;
+    /* Fixed, at a constant offset, in both open and closed states -- the
+       position value never changes on toggle, which is the only way we've
+       found that's reliably jump-free on real iOS Safari (matching
+       coordinates across an absolute/fixed switch still visibly jumped on
+       device even though the math checked out and headless testing showed
+       no jump). Floating over content while scrolled is handled separately
+       via the nav-burger-hidden class below. */
+    position: fixed;
+    left: 6vw;
+    top: 6vw;
     box-shadow: none;
     color: transparent;
     background-color: transparent;
     outline: none;
+    transition: opacity 0.2s ease-out;
   }
-  .site-head-open .nav-burger {
-    /* .site-head itself becomes fixed full-screen on open, so this offset
-       is relative to the viewport at that point. Matching it to where the
-       closed-state offset (0,0) lands once .site-wrapper's 6vw padding is
-       accounted for keeps the button visually anchored across the toggle. */
-    left: 6vw;
-    top: 6vw;
+  .nav-burger.nav-burger-hidden {
+    opacity: 0;
+    pointer-events: none;
   }
   .nav-burger:focus,
   .nav-burger:hover,


### PR DESCRIPTION
## Summary
- PR #108 made the burger `position: absolute` (relative to `.site-head`) so it'd scroll away when closed, with matching closed/open offsets computed to land at the same viewport pixel position. That math checked out and showed no jump in headless testing, but on a real iPhone it produced a visible diagonal jump (in from the top-left on open, in from the bottom-right on close) -- the containing-block switch itself (absolute -> the now-fixed `.site-head`) is apparently still glitchy on real iOS Safari, even with matched coordinates.
- This reverts the burger to `position: fixed` with completely invariant coordinates (nothing about its own CSS ever changes between open/closed), which is the only approach that's been robustly jump-free. To still avoid it floating over content while scrolled, it now fades out and becomes non-interactive (`opacity: 0; pointer-events: none`) past a small scroll threshold while the menu is closed, and reappears when scrolling back near the top.

## Test plan
- [x] Verified via Playwright that burger x/y position is bit-for-bit identical across closed -> open -> closed
- [x] Verified it fades out and stops responding to clicks once scrolled ~40px down with the menu closed
- [x] Verified it reappears and is clickable again after scrolling back to the top
- [x] Verified the bottom-sliver and markdown-image-rounding fixes from earlier PRs still hold
- [ ] User to verify on real iPhone 15 Pro


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYDxtTFpBvuEMxkv73ssko)_