### PR TITLE
Fix nav burger animation glitch on menu toggle

### DIFF
--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -300,6 +300,14 @@ body {
     outline: none;
     color: transparent;
     background-color: transparent;
+    /* The global `button:hover { transition: 0.2s ease }` rule outranks the
+       base `.nav-burger { transition: none }` once the button is tapped/hovered,
+       which silently re-enables transitions on `left`/`top`. Because opening the
+       menu flips `.site-head`'s containing block from in-flow to fixed instantly
+       while these offsets change from (0,0) to (6vw,6vw), the animated offset
+       makes the burger snap to a corner and glide back. Re-assert `none` here
+       (higher specificity than `button:hover`) so the toggle stays jump-free. */
+    transition: none;
   }
   .site-head-container {
     flex-direction: column;


### PR DESCRIPTION
## Summary
Fixed an unintended animation glitch in the navigation burger menu toggle caused by conflicting CSS transition rules.

## Key Changes
- Added explicit `transition: none` rule to `.nav-burger:active` with higher specificity to prevent unwanted animations
- The global `button:hover` transition rule was overriding the base `.nav-burger { transition: none }` declaration, causing the burger icon to animate when the menu opened
- This fix ensures the burger icon jumps instantly to its new position without the visual glitch of snapping to a corner and gliding back

## Implementation Details
The issue occurred because when the menu opens, the `.site-head` containing block switches from in-flow to fixed positioning instantly while the burger's `left`/`top` offsets change from (0,0) to (6vw,6vw). The re-enabled transitions from the `button:hover` rule caused these offset changes to animate, creating a jarring visual effect. By reasserting `transition: none` at the `:active` state with higher specificity than `button:hover`, the burger now maintains its jump-free behavior during menu toggles.

https://claude.ai/code/session_013gu6nGRUt365DyQhysp9RL