### PR TITLE
Add comprehensive SEO and build verification test suite

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: Verify SEO and build correctness against the real built dot-pe site
+---
+
+# Verify skill: dot-pe SEO + build hygiene
+
+This site has significant SEO investment (structured data, hreflang, sitemap,
+OG/Twitter cards, manifest, RSS, etc.) plus other build-output correctness
+concerns. Run this verification whenever you change anything that could
+affect head metadata, structured data, internal links, images, i18n strings,
+redirects, or the production build in general — and always before reporting
+such a change as done.
+
+## When to run it
+
+- After editing anything under `src/components/seo.js`, page/template `Head()`
+  exports, `gatsby-config.js`, `gatsby-node.js`, `siteConfig.js`, `src/i18n.js`,
+  the redirect/manifest/sitemap/feed plugin configs in `gatsby-config.js`,
+  static `robots.txt`/`llms.txt`, or markdown/page content that affects
+  images, links, or translated strings.
+- Before telling the user a SEO- or build-affecting change is complete.
+
+## Run it
+
+```bash
+npm run seo:verify
+```
+
+This does a clean `gatsby build --prefix-paths` (mirroring the real
+`deploy` script's prefixed build, kept separate so the plain `npm run build`
+stays untouched) into `public/`, then runs the assertions against that real
+output with Node's built-in test runner.
+
+If `public/` is already freshly built with `--prefix-paths` and you only
+changed test files, you can skip the rebuild:
+
+```bash
+npm run seo:verify:fast
+```
+
+## Reading results
+
+Tests live in `tests/build/*.test.js`, one file per concern (head metadata,
+JSON-LD, hreflang, sitemap, RSS, manifest, OG images, internal links, i18n,
+redirects, CSS purge safelist, image pipeline, 404, general hygiene). Each
+assertion is checked against real parsed HTML/XML in `public/`, not against
+source code, so failures point at an actual built-output defect.
+
+As of the last full pass, three pre-existing app bugs are expected to fail
+and are not test bugs:
+
+- `manifest start_url resolves to a real built page under the site prefix`
+  — `gatsby-config.js`'s manifest `start_url` already includes the site
+  prefix, and `gatsby-plugin-manifest` joins it with the path prefix again,
+  producing a doubled `/terson/terson`.
+- `og:image is absolute under the site prefix and the file exists` (a
+  handful of `/engineers/*` and `/writes/*` pages) — `src/components/seo.js`
+  only prepends the site origin to `og:image` in its default-image fallback
+  branch, not when a page passes an explicit `img` prop.
+- `every <img> src resolves to a file that was actually built` on
+  `a-tableau-web-data-connector-generator` — that page hardcodes legacy
+  `/sites/default/files/...` image paths as literal JSX strings, which
+  don't get the `--prefix-paths` prefix applied.
+
+If you fix one of these, the corresponding test will start passing — treat
+that as confirmation. Any *other* failure is a real regression to fix before
+continuing.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -46,22 +46,5 @@ redirects, CSS purge safelist, image pipeline, 404, general hygiene). Each
 assertion is checked against real parsed HTML/XML in `public/`, not against
 source code, so failures point at an actual built-output defect.
 
-As of the last full pass, three pre-existing app bugs are expected to fail
-and are not test bugs:
-
-- `manifest start_url resolves to a real built page under the site prefix`
-  — `gatsby-config.js`'s manifest `start_url` already includes the site
-  prefix, and `gatsby-plugin-manifest` joins it with the path prefix again,
-  producing a doubled `/terson/terson`.
-- `og:image is absolute under the site prefix and the file exists` (a
-  handful of `/engineers/*` and `/writes/*` pages) — `src/components/seo.js`
-  only prepends the site origin to `og:image` in its default-image fallback
-  branch, not when a page passes an explicit `img` prop.
-- `every <img> src resolves to a file that was actually built` on
-  `a-tableau-web-data-connector-generator` — that page hardcodes legacy
-  `/sites/default/files/...` image paths as literal JSX strings, which
-  don't get the `--prefix-paths` prefix applied.
-
-If you fix one of these, the corresponding test will start passing — treat
-that as confirmation. Any *other* failure is a real regression to fix before
-continuing.
+The suite is expected to be fully green — there are no known/accepted
+failures. Any failure is a real regression to fix before continuing.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -2,7 +2,7 @@
 description: Verify SEO and build correctness against the real built dot-pe site
 ---
 
-# Verify skill: dot-pe SEO + build hygiene
+# Verify skill: dot-pe build correctness
 
 This site has significant SEO investment (structured data, hreflang, sitemap,
 OG/Twitter cards, manifest, RSS, etc.) plus other build-output correctness
@@ -10,6 +10,10 @@ concerns. Run this verification whenever you change anything that could
 affect head metadata, structured data, internal links, images, i18n strings,
 redirects, or the production build in general — and always before reporting
 such a change as done.
+
+Note: this is the slower, build-against-real-output verification, intentionally
+kept out of `npm test`. `npm test` is reserved for fast, idempotent unit tests
+(of which there are none yet).
 
 ## When to run it
 
@@ -23,7 +27,7 @@ such a change as done.
 ## Run it
 
 ```bash
-npm run seo:verify
+npm run verify
 ```
 
 This does a clean `gatsby build --prefix-paths` (mirroring the real
@@ -35,7 +39,7 @@ If `public/` is already freshly built with `--prefix-paths` and you only
 changed test files, you can skip the rebuild:
 
 ```bash
-npm run seo:verify:fast
+npm run verify:fast
 ```
 
 ## Reading results

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -159,7 +159,10 @@ module.exports = {
       options: {
         name: siteConfig.name,
         short_name: siteConfig.shortName,
-        start_url: siteConfig.prefix,
+        // gatsby-plugin-manifest joins pathPrefix with start_url itself, so
+        // this must be root-relative; using siteConfig.prefix double-prefixes
+        // it to /terson/terson under --prefix-paths.
+        start_url: `/`,
         background_color: `#ffffff`,
         theme_color: `#663399`,
         display: `minimal-ui`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
       "devDependencies": {
         "autoprefixer": "^10.4.19",
         "baseline-browser-mapping": "^2.10.37",
+        "cheerio": "^1.2.0",
         "gh-pages": "^5.0.0",
         "husky": "^9.1.7",
         "postcss-custom-properties": "^13.3.12",
@@ -6518,20 +6519,26 @@
       "license": "MIT"
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=20.18.1"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -6551,6 +6558,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/chokidar": {
@@ -7797,9 +7837,10 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -7904,6 +7945,33 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -10206,6 +10274,27 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
       }
     },
+    "node_modules/gatsby-plugin-offline/node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
     "node_modules/gatsby-plugin-page-creator": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.16.0.tgz",
@@ -10495,6 +10584,27 @@
         "gatsby": "^5.0.0-next"
       }
     },
+    "node_modules/gatsby-remark-copy-linked-files/node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
     "node_modules/gatsby-remark-images": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-7.16.0.tgz",
@@ -10518,6 +10628,27 @@
       "peerDependencies": {
         "gatsby": "^5.0.0-next",
         "gatsby-plugin-sharp": "^5.0.0-next"
+      }
+    },
+    "node_modules/gatsby-remark-images/node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
       }
     },
     "node_modules/gatsby-remark-prismjs": {
@@ -10555,6 +10686,27 @@
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
+      }
+    },
+    "node_modules/gatsby-remark-responsive-iframe/node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
       }
     },
     "node_modules/gatsby-remark-smartypants": {
@@ -14928,26 +15080,53 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
       "dependencies": {
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -19175,6 +19354,16 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/unherit": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -19882,6 +20071,43 @@
       "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.19",
     "baseline-browser-mapping": "^2.10.37",
+    "cheerio": "^1.2.0",
     "gh-pages": "^5.0.0",
     "husky": "^9.1.7",
     "postcss-custom-properties": "^13.3.12",
@@ -73,7 +74,10 @@
     "prepare": "husky",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
+    "seo:build": "gatsby clean && gatsby build --prefix-paths",
+    "seo:verify": "npm run seo:build && npm run seo:verify:fast",
+    "seo:verify:fast": "node --test tests/build/*.test.js"
   },
   "browserslist": [
     "last 2 versions"

--- a/package.json
+++ b/package.json
@@ -75,9 +75,9 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\"",
-    "seo:build": "gatsby clean && gatsby build --prefix-paths",
-    "seo:verify": "npm run seo:build && npm run seo:verify:fast",
-    "seo:verify:fast": "node --test tests/build/*.test.js"
+    "verify:build": "gatsby clean && gatsby build --prefix-paths",
+    "verify": "npm run verify:build && npm run verify:fast",
+    "verify:fast": "node --test tests/build/*.test.js"
   },
   "browserslist": [
     "last 2 versions"

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -27,8 +27,13 @@ function Seo({ description, lang, meta, link, keywords, title, img, canonical, t
   `)
 
   const metaDescription = description || site.siteMetadata.description
-  const ogImage =
-    img || `${site.siteMetadata.baseUrl}${getSrc(defaultImage)}`
+  // Open Graph requires an absolute image URL. Page-supplied `img` values are
+  // usually root-relative (e.g. getSrc() -> "/terson/static/..."), so prefix
+  // them with the site origin; absolute URLs are passed through untouched.
+  const rawImage = img || getSrc(defaultImage)
+  const ogImage = /^https?:\/\//.test(rawImage)
+    ? rawImage
+    : `${site.siteMetadata.baseUrl}${rawImage}`
   const ogType = type || `website`
   const twitterHandle = site.siteMetadata.social.twitter
 

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -8,15 +8,15 @@ import Seo from "../components/seo"
 
 class PreNotFoundPage extends React.Component {
   render() {
-    const { t, i18n } = this.props
+    const { i18n } = this.props
     const { data, location } = this.props
     const siteTitle = data.site.siteMetadata.title
-    let LocalLayout = EnLayout
-
-    if (location.pathname.indexOf("/sv") === 0) {
-      i18n.changeLanguage("sv")
-      LocalLayout = SvLayout
-    }
+    const isSv = location.pathname.indexOf("/sv") === 0
+    const LocalLayout = isSv ? SvLayout : EnLayout
+    // getFixedT resolves the language explicitly per render instead of mutating
+    // the shared i18next singleton, which otherwise leaks language between pages
+    // during the SSR build (English /404.html rendering Swedish copy, etc.).
+    const t = i18n.getFixedT(isSv ? "sv" : "en")
 
     return (
       <LocalLayout location={location} title={siteTitle}>

--- a/src/pages/engineers/a-tableau-web-data-connector-generator.js
+++ b/src/pages/engineers/a-tableau-web-data-connector-generator.js
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, withPrefix } from "gatsby"
 import { GatsbyImage, getImage, getSrc } from "gatsby-plugin-image"
 
 import Layout from "../../layouts/en"
@@ -188,7 +188,9 @@ const LegacyWdcGeneratorPage = ({ data, location }) => {
           </p>
           <hr />
           <img
-            src="/sites/default/files/field/image/yo-web-data-connector.gif"
+            src={withPrefix(
+              "/sites/default/files/field/image/yo-web-data-connector.gif"
+            )}
             alt="Demonstration of generator CLI."
             className="kg-image"
           />
@@ -239,7 +241,9 @@ const LegacyWdcGeneratorPage = ({ data, location }) => {
           </p>
           <hr />
           <img
-            src="/sites/default/files/field/image/grunt-web-data-connector-dual-screen-open.gif"
+            src={withPrefix(
+              "/sites/default/files/field/image/grunt-web-data-connector-dual-screen-open.gif"
+            )}
             alt="Demonstration of building and opening the generated connector."
             className="kg-image"
           />

--- a/tests/build/core-pages.js
+++ b/tests/build/core-pages.js
@@ -1,0 +1,16 @@
+const { PREFIX } = require("./load")
+
+// Pages that map 1:1 to a known source file (as opposed to generated blog
+// posts, which are identified at runtime by their og:type=article marker).
+const CORE_PAGES = [
+  { sitePath: `${PREFIX}/`, lang: "en-US" },
+  { sitePath: `${PREFIX}/sv/`, lang: "sv-SE" },
+  { sitePath: `${PREFIX}/posts/`, lang: "en-US" },
+  { sitePath: `${PREFIX}/sv/posts/`, lang: "sv-SE" },
+  { sitePath: `${PREFIX}/engineers/a-tableau-web-data-connector-generator/` },
+  { sitePath: `${PREFIX}/engineers/better-wdc-performance-with-promises/` },
+  { sitePath: `${PREFIX}/writes/a-response-to-sou-2025-1/` },
+  { sitePath: `${PREFIX}/sv/writes/a-response-to-sou-2025-1/` },
+]
+
+module.exports = { CORE_PAGES }

--- a/tests/build/load.js
+++ b/tests/build/load.js
@@ -1,0 +1,115 @@
+const fs = require("fs")
+const path = require("path")
+const cheerio = require("cheerio")
+const siteConfig = require("../../siteConfig")
+
+const ROOT = path.resolve(__dirname, "../..")
+const PUBLIC_DIR = path.join(ROOT, "public")
+const ORIGIN = siteConfig.url // e.g. https://eric.pe
+const PREFIX = siteConfig.prefix // e.g. /terson
+const SITE_URL = `${ORIGIN}${PREFIX}` // e.g. https://eric.pe/terson
+
+const SKIP_DIRS = new Set(["page-data", "_gatsby"])
+
+if (!fs.existsSync(PUBLIC_DIR)) {
+  throw new Error(
+    `public/ not found. Run "npm run seo:build" before "npm run seo:verify", ` +
+      `or just use "npm run seo:verify" which does both.`
+  )
+}
+
+function walk(dir, results) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) continue
+      walk(path.join(dir, entry.name), results)
+    } else if (entry.name.endsWith(".html")) {
+      results.push(path.join(dir, entry.name))
+    }
+  }
+  return results
+}
+
+// Maps a built file path to the site-relative path it's served at (prefix included),
+// e.g. public/records/foo/index.html -> /terson/records/foo/
+function filePathToSitePath(filePath) {
+  const rel = path.relative(PUBLIC_DIR, filePath)
+  if (path.basename(rel) === "index.html") {
+    const dir = path.dirname(rel)
+    return dir === "." ? `${PREFIX}/` : `${PREFIX}/${dir}/`
+  }
+  return `${PREFIX}/${rel}`
+}
+
+// Infrastructure pages (client-side redirect stubs, the offline-plugin app
+// shell) carry no real SEO surface of their own and are exempt from the
+// generic per-page content checks; they're still addressable via getPage().
+function isInfraSitePath(sitePath) {
+  return sitePath.endsWith("/is/") || sitePath.includes("offline-plugin-app-shell-fallback")
+}
+
+const pages = walk(PUBLIC_DIR, []).map((file) => {
+  const html = fs.readFileSync(file, "utf8")
+  const $ = cheerio.load(html)
+  const sitePath = filePathToSitePath(file)
+  const ogType = $('meta[property="og:type"]').attr("content")
+  return {
+    file,
+    sitePath,
+    url: `${ORIGIN}${sitePath}`,
+    html,
+    $,
+    isArticle: ogType === "article",
+    isInfra: isInfraSitePath(sitePath),
+  }
+})
+
+const contentPages = pages.filter((p) => !p.isInfra)
+
+const pagesBySitePath = new Map(pages.map((p) => [p.sitePath, p]))
+
+function getPage(sitePath) {
+  return pagesBySitePath.get(sitePath)
+}
+
+// Strips origin/query/hash from a URL and maps it to an absolute filesystem path
+// under public/, or null if it doesn't live under our path prefix.
+function resolveToFsPath(url) {
+  let u = url.startsWith(ORIGIN) ? url.slice(ORIGIN.length) : url
+  u = u.split("?")[0].split("#")[0]
+  if (!u.startsWith(PREFIX)) return null
+  let rel = u.slice(PREFIX.length)
+  if (rel === "") rel = "/"
+  if (rel.endsWith("/")) rel += "index.html"
+  return path.join(PUBLIC_DIR, rel)
+}
+
+function assetExists(url) {
+  const fsPath = resolveToFsPath(url)
+  return fsPath !== null && fs.existsSync(fsPath)
+}
+
+function readPublicText(relPath) {
+  const fsPath = path.join(PUBLIC_DIR, relPath)
+  return fs.existsSync(fsPath) ? fs.readFileSync(fsPath, "utf8") : null
+}
+
+function readPublicXml(relPath) {
+  const text = readPublicText(relPath)
+  return text === null ? null : cheerio.load(text, { xmlMode: true })
+}
+
+module.exports = {
+  ROOT,
+  PUBLIC_DIR,
+  ORIGIN,
+  PREFIX,
+  SITE_URL,
+  pages,
+  contentPages,
+  getPage,
+  resolveToFsPath,
+  assetExists,
+  readPublicText,
+  readPublicXml,
+}

--- a/tests/build/seo.article.test.js
+++ b/tests/build/seo.article.test.js
@@ -1,0 +1,58 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { pages, SITE_URL } = require("./load")
+
+const articles = pages.filter((p) => p.isArticle)
+
+test("at least one article page was found to test", () => {
+  assert.ok(articles.length > 0)
+})
+
+for (const page of articles) {
+  const { $, sitePath } = page
+
+  test(`${sitePath}: article:published_time is a valid ISO date`, () => {
+    const published = $('meta[property="article:published_time"]').attr("content")
+    assert.ok(published, "missing article:published_time")
+    assert.ok(!Number.isNaN(Date.parse(published)), `not a valid date: ${published}`)
+  })
+
+  test(`${sitePath}: article:author is set`, () => {
+    assert.ok($('meta[property="article:author"]').attr("content"))
+  })
+
+  test(`${sitePath}: article:modified_time is absent (no post sets a modified date yet)`, () => {
+    assert.equal($('meta[property="article:modified_time"]').length, 0)
+  })
+
+  test(`${sitePath}: links to the correct language RSS feed`, () => {
+    const isSv = sitePath.includes("/sv/")
+    const expected = `${SITE_URL}/rss${isSv ? ".sv" : ""}.xml`
+    const rssLink = $('link[type="application/rss+xml"]').attr("href")
+    assert.equal(rssLink, expected)
+  })
+
+  const ogVideo = $('meta[property="og:video"]')
+  if (ogVideo.length) {
+    test(`${sitePath}: video post has og:video secure_url + type`, () => {
+      assert.ok($('meta[property="og:video:secure_url"]').attr("content"))
+      assert.equal(
+        $('meta[property="og:video:type"]').attr("content"),
+        "text/html"
+      )
+    })
+  }
+
+  const alternate = $('link[rel="alternate"][hreflang]')
+  if (alternate.length) {
+    test(`${sitePath}: translated post's hreflang alternate points to the other language`, () => {
+      const isSv = sitePath.includes("/sv/")
+      const hreflang = alternate.attr("hreflang")
+      assert.equal(hreflang, isSv ? "en" : "sv")
+      const href = alternate.attr("href")
+      assert.ok(href.startsWith(SITE_URL))
+      if (isSv) assert.ok(!href.includes("/sv/"))
+      else assert.ok(href.includes("/sv/"))
+    })
+  }
+}

--- a/tests/build/seo.head.test.js
+++ b/tests/build/seo.head.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { contentPages: pages, SITE_URL } = require("./load")
+
+function meta($, attr, value) {
+  return $(`meta[${attr}="${value}"]`).first()
+}
+
+for (const page of pages) {
+  const { $, sitePath } = page
+
+  test(`${sitePath}: title is "<page> | Eric Peterson"`, () => {
+    const title = $("title").first().text()
+    assert.match(title, /^.+ \| Eric Peterson$/, `got "${title}"`)
+  })
+
+  test(`${sitePath}: has a non-empty description`, () => {
+    const description = meta($, "name", "description").attr("content")
+    assert.ok(description && description.trim().length > 0)
+  })
+
+  test(`${sitePath}: has full Open Graph + Twitter card set`, () => {
+    for (const prop of ["og:title", "og:description", "og:type", "og:image"]) {
+      assert.ok(meta($, "property", prop).length, `missing ${prop}`)
+    }
+    assert.equal(
+      meta($, "name", "twitter:card").attr("content"),
+      "summary_large_image"
+    )
+    assert.equal(meta($, "name", "twitter:site").attr("content"), "@iamEAP")
+    assert.equal(meta($, "name", "twitter:creator").attr("content"), "@iamEAP")
+    for (const name of ["twitter:title", "twitter:description", "twitter:image"]) {
+      assert.ok(meta($, "name", name).length, `missing ${name}`)
+    }
+  })
+
+  test(`${sitePath}: html lang is set`, () => {
+    const lang = $("html").attr("lang")
+    assert.ok(lang === "en-US" || lang === "sv-SE" || lang === "en", `got "${lang}"`)
+  })
+
+  const canonical = $('link[rel="canonical"]').attr("href")
+  if (canonical) {
+    test(`${sitePath}: canonical is absolute, under ${SITE_URL}, trailing slash`, () => {
+      assert.ok(canonical.startsWith(SITE_URL))
+      assert.ok(canonical.endsWith("/"))
+    })
+
+    test(`${sitePath}: og:url matches canonical when present`, () => {
+      const ogUrl = meta($, "property", "og:url").attr("content")
+      if (ogUrl) assert.equal(ogUrl, canonical)
+    })
+  }
+}

--- a/tests/build/seo.hreflang.test.js
+++ b/tests/build/seo.hreflang.test.js
@@ -1,0 +1,41 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { getPage, SITE_URL, PREFIX } = require("./load")
+
+// The about pages intentionally point hreflang alternates at the legacy
+// "/is" redirect slugs rather than "/" and "/sv/" directly; that's existing,
+// deliberate behavior (see gatsby-node.js createRedirect), not a bug.
+const pairs = [
+  {
+    en: `${PREFIX}/`,
+    sv: `${PREFIX}/sv/`,
+    enAlternateHref: `${SITE_URL}/sv/is/`,
+    svAlternateHref: `${SITE_URL}/is/`,
+  },
+  {
+    en: `${PREFIX}/posts/`,
+    sv: `${PREFIX}/sv/posts/`,
+    enAlternateHref: `${SITE_URL}/sv/posts/`,
+    svAlternateHref: `${SITE_URL}/posts/`,
+  },
+]
+
+for (const { en, sv, enAlternateHref, svAlternateHref } of pairs) {
+  test(`${en} <-> ${sv}: reciprocal hreflang alternates`, () => {
+    const enPage = getPage(en)
+    const svPage = getPage(sv)
+    assert.ok(enPage, `missing ${en}`)
+    assert.ok(svPage, `missing ${sv}`)
+
+    const enAlternate = enPage.$('link[rel="alternate"][hreflang="sv"]').attr("href")
+    const svAlternate = svPage.$('link[rel="alternate"][hreflang="en"]').attr("href")
+
+    assert.equal(enAlternate, enAlternateHref)
+    assert.equal(svAlternate, svAlternateHref)
+  })
+
+  test(`${en} <-> ${sv}: html lang matches the page's language`, () => {
+    assert.equal(getPage(en).$("html").attr("lang"), "en-US")
+    assert.equal(getPage(sv).$("html").attr("lang"), "sv-SE")
+  })
+}

--- a/tests/build/seo.identity.test.js
+++ b/tests/build/seo.identity.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { pages, SITE_URL } = require("./load")
+
+function parseLdJsonBlocks($) {
+  const blocks = []
+  $('script[type="application/ld+json"]').each((_, el) => {
+    blocks.push(JSON.parse($(el).contents().text()))
+  })
+  return blocks
+}
+
+function flattenNodes(blocks) {
+  const nodes = []
+  for (const block of blocks) {
+    if (Array.isArray(block["@graph"])) nodes.push(...block["@graph"])
+    else nodes.push(block)
+  }
+  return nodes
+}
+
+test("#person identity is consistent (same @id + name) across every page that references it", () => {
+  const expectedId = `${SITE_URL}/#person`
+  let seenName = null
+  let sawPerson = false
+
+  for (const page of pages) {
+    const nodes = flattenNodes(parseLdJsonBlocks(page.$))
+    const persons = nodes.filter((n) => n["@type"] === "Person" && n["@id"])
+    for (const person of persons) {
+      assert.equal(person["@id"], expectedId, `${page.sitePath}: unexpected Person @id`)
+      sawPerson = true
+      if (seenName === null) {
+        seenName = person.name
+      } else {
+        assert.equal(person.name, seenName, `${page.sitePath}: name diverges`)
+      }
+    }
+  }
+
+  assert.ok(sawPerson, "expected at least one Person node across the site")
+})

--- a/tests/build/seo.jsonld.test.js
+++ b/tests/build/seo.jsonld.test.js
@@ -1,0 +1,95 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { pages } = require("./load")
+
+function parseLdJsonBlocks($) {
+  const blocks = []
+  $('script[type="application/ld+json"]').each((_, el) => {
+    blocks.push(JSON.parse($(el).contents().text()))
+  })
+  return blocks
+}
+
+// Flattens top-level docs and @graph arrays into a single list of typed nodes.
+function flattenNodes(blocks) {
+  const nodes = []
+  for (const block of blocks) {
+    if (Array.isArray(block["@graph"])) nodes.push(...block["@graph"])
+    else nodes.push(block)
+  }
+  return nodes
+}
+
+for (const page of pages) {
+  const { $, sitePath } = page
+  const scripts = $('script[type="application/ld+json"]')
+  if (!scripts.length) continue
+
+  test(`${sitePath}: all ld+json blocks parse as valid JSON`, () => {
+    assert.doesNotThrow(() => parseLdJsonBlocks($))
+  })
+
+  const blocks = parseLdJsonBlocks($)
+  const nodes = flattenNodes(blocks)
+
+  test(`${sitePath}: every node has @type and uses https://schema.org context`, () => {
+    for (const block of blocks) {
+      if (block["@context"]) assert.equal(block["@context"], "https://schema.org")
+    }
+    for (const node of nodes) {
+      assert.ok(node["@type"], `node missing @type: ${JSON.stringify(node)}`)
+    }
+  })
+
+  const person = nodes.find((n) => n["@type"] === "Person")
+  if (person) {
+    test(`${sitePath}: Person node has @id, name, and url`, () => {
+      assert.ok(person["@id"] && person["@id"].endsWith("#person"))
+      assert.ok(person.name)
+      assert.ok(person.url)
+    })
+  }
+
+  const blogPosting = nodes.find((n) => n["@type"] === "BlogPosting")
+  if (blogPosting) {
+    test(`${sitePath}: BlogPosting has headline/description/datePublished/url/inLanguage`, () => {
+      assert.ok(blogPosting.headline)
+      assert.ok(blogPosting.description)
+      assert.ok(!Number.isNaN(Date.parse(blogPosting.datePublished)))
+      assert.ok(blogPosting.url)
+      assert.ok(["en-US", "sv-SE"].includes(blogPosting.inLanguage))
+    })
+
+    test(`${sitePath}: BlogPosting.url matches the page's canonical`, () => {
+      const canonical = $('link[rel="canonical"]').attr("href")
+      if (canonical) assert.equal(blogPosting.url, canonical)
+    })
+
+    test(`${sitePath}: BlogPosting.author resolves to a Person node on the same page`, () => {
+      assert.ok(blogPosting.author && blogPosting.author["@id"])
+      const author = nodes.find(
+        (n) => n["@type"] === "Person" && n["@id"] === blogPosting.author["@id"]
+      )
+      assert.ok(author, `no matching Person node for ${blogPosting.author["@id"]}`)
+    })
+  }
+
+  const musicNode = nodes.find(
+    (n) => n["@type"] === "MusicRecording" || n["@type"] === "MusicPlaylist"
+  )
+  if (musicNode) {
+    test(`${sitePath}: music node has a performer (byArtist or creator) and datePublished`, () => {
+      assert.ok(musicNode.byArtist || musicNode.creator, "missing byArtist/creator")
+      assert.ok(!Number.isNaN(Date.parse(musicNode.datePublished)))
+    })
+  }
+
+  const videoNode = blocks.find((n) => n["@type"] === "VideoObject")
+  if (videoNode) {
+    test(`${sitePath}: VideoObject has name/embedUrl/uploadDate`, () => {
+      assert.ok(videoNode.name)
+      assert.ok(videoNode.embedUrl)
+      assert.ok(!Number.isNaN(Date.parse(videoNode.uploadDate)))
+    })
+  }
+}

--- a/tests/build/seo.manifest.test.js
+++ b/tests/build/seo.manifest.test.js
@@ -1,0 +1,40 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { readPublicText, assetExists, contentPages: pages, PREFIX } = require("./load")
+
+test("manifest.webmanifest is valid JSON with required fields", () => {
+  const text = readPublicText("manifest.webmanifest")
+  assert.ok(text, "manifest.webmanifest not found in public/")
+  const manifest = JSON.parse(text)
+  assert.ok(manifest.name)
+  assert.ok(manifest.short_name)
+  assert.ok(manifest.icons && manifest.icons.length > 0)
+})
+
+test("manifest start_url resolves to a real built page under the site prefix", () => {
+  const manifest = JSON.parse(readPublicText("manifest.webmanifest"))
+  assert.ok(
+    manifest.start_url.startsWith(PREFIX),
+    `start_url should live under ${PREFIX}, got ${manifest.start_url}`
+  )
+  assert.ok(
+    assetExists(manifest.start_url),
+    `manifest start_url does not resolve to a built page: ${manifest.start_url}`
+  )
+})
+
+test("every manifest icon file exists in the build", () => {
+  const manifest = JSON.parse(readPublicText("manifest.webmanifest"))
+  for (const icon of manifest.icons) {
+    assert.ok(assetExists(icon.src), `manifest icon missing from build: ${icon.src}`)
+  }
+})
+
+test("every page links the manifest", () => {
+  for (const page of pages) {
+    assert.ok(
+      page.$('link[rel="manifest"]').length,
+      `${page.sitePath} is missing <link rel="manifest">`
+    )
+  }
+})

--- a/tests/build/seo.og-images.test.js
+++ b/tests/build/seo.og-images.test.js
@@ -1,0 +1,18 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { contentPages: pages, SITE_URL, assetExists } = require("./load")
+
+for (const page of pages) {
+  const { $, sitePath } = page
+  const ogImage = $('meta[property="og:image"]').attr("content")
+  if (!ogImage) continue
+
+  test(`${sitePath}: og:image is absolute under the site prefix and the file exists`, () => {
+    assert.ok(ogImage.startsWith(SITE_URL), `not under ${SITE_URL}: ${ogImage}`)
+    assert.ok(assetExists(ogImage), `og:image file does not exist in public/: ${ogImage}`)
+  })
+
+  test(`${sitePath}: twitter:image matches og:image`, () => {
+    assert.equal($('meta[name="twitter:image"]').attr("content"), ogImage)
+  })
+}

--- a/tests/build/seo.pages-exist.test.js
+++ b/tests/build/seo.pages-exist.test.js
@@ -1,0 +1,49 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("fs")
+const path = require("path")
+const { pages, getPage, ROOT, PREFIX } = require("./load")
+const { CORE_PAGES } = require("./core-pages")
+
+test("every core page exists in the build", () => {
+  for (const { sitePath } of CORE_PAGES) {
+    assert.ok(getPage(sitePath), `expected built page at ${sitePath}`)
+  }
+})
+
+test("404 page exists at both /404.html and /404/", () => {
+  assert.ok(getPage(`${PREFIX}/404.html`))
+  assert.ok(getPage(`${PREFIX}/404/`))
+})
+
+test("no duplicate pages share the same head title/description/canonical", () => {
+  const seen = new Map()
+  for (const page of pages) {
+    const title = page.$("title").first().text()
+    const key = `${page.sitePath}::${title}`
+    assert.ok(!seen.has(key), `duplicate title detected: ${key}`)
+    seen.set(key, true)
+  }
+})
+
+test("a reasonable number of article (blog post) pages were built", () => {
+  const contentBlogDir = path.join(ROOT, "content/blog")
+  const leafDirs = []
+  function walk(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    const hasMd = entries.some((e) => e.isFile() && e.name.endsWith(".md"))
+    if (hasMd) leafDirs.push(dir)
+    for (const e of entries) {
+      if (e.isDirectory()) walk(path.join(dir, e.name))
+    }
+  }
+  walk(contentBlogDir)
+
+  const articlePages = pages.filter((p) => p.isArticle)
+  // Floor check: every content leaf directory should produce at least one
+  // article page (translations may add more than one per directory).
+  assert.ok(
+    articlePages.length >= leafDirs.length,
+    `expected at least ${leafDirs.length} article pages, found ${articlePages.length}`
+  )
+})

--- a/tests/build/seo.relme.test.js
+++ b/tests/build/seo.relme.test.js
@@ -1,0 +1,41 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { pages } = require("./load")
+
+const aboutPages = pages.filter((p) =>
+  p.$('script[type="application/ld+json"]')
+    .toArray()
+    .some((el) => {
+      try {
+        return JSON.parse(p.$(el).contents().text())["@type"] === "Person"
+      } catch {
+        return false
+      }
+    })
+)
+
+test("at least one about/Person page was found to test rel=me on", () => {
+  assert.ok(aboutPages.length > 0)
+})
+
+for (const page of aboutPages) {
+  const { $, sitePath } = page
+
+  test(`${sitePath}: rel=me links match the Person node's sameAs`, () => {
+    const jsonLd = JSON.parse(
+      $('script[type="application/ld+json"]').first().contents().text()
+    )
+    const sameAs = jsonLd.sameAs || []
+    const relMeHrefs = $('link[rel="me"]')
+      .map((_, el) => $(el).attr("href"))
+      .get()
+
+    assert.ok(sameAs.length > 0, "Person node has no sameAs links")
+    for (const href of sameAs) {
+      assert.ok(relMeHrefs.includes(href), `sameAs ${href} missing from rel=me links`)
+    }
+    for (const href of relMeHrefs) {
+      assert.ok(sameAs.includes(href), `rel=me ${href} missing from sameAs`)
+    }
+  })
+}

--- a/tests/build/seo.robots-llms.test.js
+++ b/tests/build/seo.robots-llms.test.js
@@ -1,0 +1,26 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { readPublicText, assetExists, SITE_URL } = require("./load")
+
+test("robots.txt allows crawling and points at the correct sitemap", () => {
+  const text = readPublicText("robots.txt")
+  assert.ok(text, "robots.txt not found in public/")
+  assert.match(text, /User-agent:\s*\*/)
+  assert.match(text, /Disallow:\s*$/m)
+  assert.match(
+    text,
+    new RegExp(`Sitemap:\\s*${SITE_URL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/sitemap-index\\.xml`)
+  )
+})
+
+test("llms.txt exists and its key links resolve to real built pages", () => {
+  const text = readPublicText("llms.txt")
+  assert.ok(text, "llms.txt not found in public/")
+
+  const links = [...text.matchAll(/\((https:\/\/[^\s)]+)\)/g)].map((m) => m[1])
+  const internalLinks = links.filter((url) => url.startsWith(SITE_URL))
+  assert.ok(internalLinks.length > 0, "expected llms.txt to link to at least one site page")
+  for (const url of internalLinks) {
+    assert.ok(assetExists(url), `llms.txt links to a non-existent page/file: ${url}`)
+  }
+})

--- a/tests/build/seo.rss.test.js
+++ b/tests/build/seo.rss.test.js
@@ -1,0 +1,37 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { readPublicXml, assetExists, SITE_URL } = require("./load")
+
+for (const [file, expectedLangSegment] of [
+  ["rss.xml", null],
+  ["rss.sv.xml", "/sv/"],
+]) {
+  test(`${file}: is valid XML with channel metadata`, () => {
+    const $ = readPublicXml(file)
+    assert.ok($, `${file} not found in public/`)
+    assert.ok($("channel > title").text().length > 0)
+    assert.ok($("channel > description").text().length > 0)
+    assert.equal($("channel > link").first().text(), SITE_URL)
+  })
+
+  test(`${file}: every item has guid/pubDate/content:encoded and an absolute, resolvable link`, () => {
+    const $ = readPublicXml(file)
+    const items = $("item")
+    assert.ok(items.length > 0, `${file} has no items`)
+    items.each((_, el) => {
+      const item = $(el)
+      const link = item.find("link").first().text()
+      assert.ok(link.startsWith(SITE_URL), `non-absolute item link: ${link}`)
+      assert.ok(assetExists(link), `item link does not resolve to a built page: ${link}`)
+      assert.ok(item.find("guid").text().length > 0)
+      assert.ok(!Number.isNaN(Date.parse(item.find("pubDate").text())))
+      assert.ok(item.find("content\\:encoded").text().length > 0)
+
+      if (expectedLangSegment) {
+        assert.ok(link.includes(expectedLangSegment), `${file} item should be Swedish: ${link}`)
+      } else {
+        assert.ok(!link.includes("/sv/"), `${file} item should be English: ${link}`)
+      }
+    })
+  })
+}

--- a/tests/build/seo.sitemap.test.js
+++ b/tests/build/seo.sitemap.test.js
@@ -1,0 +1,76 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { readPublicXml, assetExists, SITE_URL, pages } = require("./load")
+
+test("sitemap-index.xml references sitemap-0.xml with the full prefixed URL", () => {
+  const $ = readPublicXml("sitemap-index.xml")
+  assert.ok($, "sitemap-index.xml not found")
+  const locs = $("sitemap > loc")
+    .map((_, el) => $(el).text())
+    .get()
+  assert.deepEqual(locs, [`${SITE_URL}/sitemap-0.xml`])
+})
+
+test("sitemap-0.xml is valid and excludes 404 pages", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  assert.ok($, "sitemap-0.xml not found")
+  const urls = $("url > loc")
+    .map((_, el) => $(el).text())
+    .get()
+  assert.ok(urls.length > 0)
+  for (const url of urls) {
+    assert.ok(!url.includes("/404"), `sitemap should not include 404: ${url}`)
+  }
+})
+
+test("every sitemap url is absolute, under the site prefix, and has a trailing slash", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  $("url > loc").each((_, el) => {
+    const url = $(el).text()
+    assert.ok(url.startsWith(SITE_URL), `not under ${SITE_URL}: ${url}`)
+    assert.ok(url.endsWith("/"), `missing trailing slash: ${url}`)
+  })
+})
+
+test("every sitemap url resolves to a page that was actually built", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  $("url > loc").each((_, el) => {
+    const url = $(el).text()
+    assert.ok(assetExists(url), `sitemap references a non-existent page: ${url}`)
+  })
+})
+
+test("every sitemap url has x-default/en/sv hreflang alternates", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  $("url").each((_, urlEl) => {
+    const langs = $(urlEl)
+      .find("xhtml\\:link")
+      .map((_, el) => $(el).attr("hreflang"))
+      .get()
+    for (const lang of ["x-default", "en", "sv"]) {
+      assert.ok(langs.includes(lang), `${$(urlEl).find("loc").text()} missing hreflang=${lang}`)
+    }
+  })
+})
+
+test("homepage has priority 1.0; other pages have a lower priority", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  $("url").each((_, urlEl) => {
+    const loc = $(urlEl).find("loc").text()
+    const priority = $(urlEl).find("priority").text()
+    const isHome = loc === `${SITE_URL}/` || loc === `${SITE_URL}/sv/`
+    assert.equal(priority, isHome ? "1.0" : "0.7", `unexpected priority for ${loc}`)
+  })
+})
+
+test("core built pages are represented in the sitemap", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  const urls = new Set(
+    $("url > loc")
+      .map((_, el) => $(el).text())
+      .get()
+  )
+  const articlePage = pages.find((p) => p.isArticle)
+  assert.ok(articlePage, "no article pages to check against the sitemap")
+  assert.ok(urls.has(articlePage.url), `${articlePage.url} missing from sitemap`)
+})

--- a/tests/build/site.404.test.js
+++ b/tests/build/site.404.test.js
@@ -1,0 +1,17 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { getPage, PREFIX } = require("./load")
+
+test("404 page has the expected title and visible copy", () => {
+  const page = getPage(`${PREFIX}/404.html`)
+  assert.ok(page, "404.html not built")
+  assert.match(page.$("title").text(), /^404: Not Found \|/)
+  assert.match(page.$("body").text(), /Not Found/)
+})
+
+test("/404/ and /404.html render the same head metadata", () => {
+  const dirPage = getPage(`${PREFIX}/404/`)
+  const filePage = getPage(`${PREFIX}/404.html`)
+  assert.ok(dirPage && filePage)
+  assert.equal(dirPage.$("title").text(), filePage.$("title").text())
+})

--- a/tests/build/site.css-purge.test.js
+++ b/tests/build/site.css-purge.test.js
@@ -1,0 +1,24 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const fs = require("fs")
+const path = require("path")
+const { PUBLIC_DIR } = require("./load")
+
+function findBuiltCss() {
+  return fs
+    .readdirSync(PUBLIC_DIR)
+    .filter((f) => f.endsWith(".css"))
+    .map((f) => fs.readFileSync(path.join(PUBLIC_DIR, f), "utf8"))
+    .join("\n")
+}
+
+test("PurgeCSS safelist preserves Ghost/markdown content classes (kg-*, gatsby-resp-image-*)", () => {
+  const css = findBuiltCss()
+  assert.ok(css.length > 0, "no built CSS files found in public/")
+  assert.match(css, /\.kg-/, "expected at least one .kg-* rule to survive purging")
+  assert.match(
+    css,
+    /\.gatsby-resp-image/,
+    "expected at least one .gatsby-resp-image* rule to survive purging"
+  )
+})

--- a/tests/build/site.hygiene.test.js
+++ b/tests/build/site.hygiene.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { contentPages: pages, assetExists } = require("./load")
+
+const BAD_PATTERNS = [/undefined/, /\bnull\b/, /NaN/, /\[object Object\]/]
+
+for (const page of pages) {
+  const { $, sitePath } = page
+
+  test(`${sitePath}: head metadata content has no stringified-undefined/null/NaN/object leaks`, () => {
+    $("meta[content], title, link[href]").each((_, el) => {
+      const value = $(el).attr("content") || $(el).text() || $(el).attr("href") || ""
+      for (const pattern of BAD_PATTERNS) {
+        assert.doesNotMatch(value, pattern, `bad value in <head>: "${value}"`)
+      }
+    })
+  })
+
+  test(`${sitePath}: visible body text has no stringified-undefined/null/NaN/object leaks`, () => {
+    // Strip <script>/<style> content first; inline JS bundles legitimately
+    // contain tokens like "null" or "undefined" that aren't rendered content.
+    const bodyText = $("body").clone().find("script, style").remove().end().text()
+    for (const pattern of BAD_PATTERNS) {
+      assert.doesNotMatch(bodyText, pattern)
+    }
+  })
+
+  test(`${sitePath}: charset and viewport meta tags are present`, () => {
+    assert.ok($("meta[charset], meta[charSet]").length > 0)
+    assert.ok($('meta[name="viewport"]').length > 0)
+  })
+
+  const fontPreload = $('link[rel="preload"][as="font"]').attr("href")
+  if (fontPreload) {
+    test(`${sitePath}: preloaded font file exists in the build`, () => {
+      assert.ok(assetExists(fontPreload), `preloaded font missing: ${fontPreload}`)
+    })
+  }
+}

--- a/tests/build/site.i18n.test.js
+++ b/tests/build/site.i18n.test.js
@@ -1,0 +1,41 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { contentPages: pages } = require("./load")
+
+// Mirrors src/i18n.js resources. Kept here (rather than imported) so this
+// test fails loudly if the translation strings ever drift out of sync.
+const TRANSLATIONS = [
+  { en: "Fast-forward to", sv: "Spola framåt till" },
+  { en: "Rewind to", sv: "Spola tillbaka till" },
+  { en: "There will probably be more", sv: "Det kommer nog att finnas fler" },
+  { en: "There was probably more", sv: "Det fanns nog fler" },
+  { en: "Not Found", sv: "Ej Hittad" },
+  {
+    en: "You just hit a page that doesn't exist",
+    sv: "Du hittade precis en sida som inte finns",
+  },
+]
+
+for (const page of pages) {
+  const { sitePath } = page
+  const isSv = sitePath.includes("/sv/")
+  const bodyText = page.$("body").text()
+
+  test(`${sitePath}: no unrendered i18n interpolation placeholders`, () => {
+    assert.doesNotMatch(bodyText, /\{\{\s*\w+\s*\}\}/)
+  })
+
+  for (const { en, sv } of TRANSLATIONS) {
+    if (!bodyText.includes(en) && !bodyText.includes(sv)) continue
+
+    test(`${sitePath}: renders the ${isSv ? "Swedish" : "English"} translation, not the other language's`, () => {
+      if (isSv) {
+        assert.ok(bodyText.includes(sv), `expected Swedish text "${sv}"`)
+        assert.ok(!bodyText.includes(en), `leaked English text "${en}"`)
+      } else {
+        assert.ok(bodyText.includes(en), `expected English text "${en}"`)
+        assert.ok(!bodyText.includes(sv), `leaked Swedish text "${sv}"`)
+      }
+    })
+  }
+}

--- a/tests/build/site.images.test.js
+++ b/tests/build/site.images.test.js
@@ -1,0 +1,37 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { contentPages: pages, assetExists } = require("./load")
+
+for (const page of pages) {
+  const { $, sitePath } = page
+  const images = $("img")
+  if (!images.length) continue
+
+  test(`${sitePath}: every <img> has a non-empty alt attribute`, () => {
+    images.each((_, el) => {
+      const alt = $(el).attr("alt")
+      assert.ok(alt !== undefined, `<img src="${$(el).attr("src")}"> is missing alt`)
+    })
+  })
+
+  test(`${sitePath}: every <img> src resolves to a file that was actually built`, () => {
+    images.each((_, el) => {
+      const src = $(el).attr("src")
+      if (!src || src.startsWith("data:")) return
+      assert.ok(assetExists(src), `<img> references a missing file on ${sitePath}: ${src}`)
+    })
+  })
+
+  const gatsbyImages = $('[data-gatsby-image-wrapper], .gatsby-image-wrapper')
+  if (gatsbyImages.length) {
+    // cheerio (HTML mode) treats <noscript> contents as raw text, so the
+    // noscript fallback <img srcSet> is invisible here; the JS-hydrated
+    // <img> instead carries the equivalent data-srcset before hydration.
+    test(`${sitePath}: gatsby-plugin-image responsive markup includes srcset`, () => {
+      const hasSrcset = images
+        .toArray()
+        .some((el) => $(el).attr("srcset") || $(el).attr("srcSet") || $(el).attr("data-srcset"))
+      assert.ok(hasSrcset, "expected at least one responsive <img srcset> on a page with gatsby-image")
+    })
+  }
+}

--- a/tests/build/site.links.test.js
+++ b/tests/build/site.links.test.js
@@ -1,0 +1,22 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { pages, assetExists, SITE_URL } = require("./load")
+
+for (const page of pages) {
+  const { $, sitePath } = page
+  const internalLinks = $("a[href]")
+    .map((_, el) => $(el).attr("href"))
+    .get()
+    .filter((href) => href.startsWith(SITE_URL) || href.startsWith("/"))
+
+  if (!internalLinks.length) continue
+
+  test(`${sitePath}: every internal link resolves to a built page`, () => {
+    for (const href of internalLinks) {
+      // Skip anchors and root-relative links outside the site prefix
+      // (none expected, but guards against false positives on bare "/").
+      if (href === "/" || href.startsWith("#")) continue
+      assert.ok(assetExists(href), `dead internal link on ${sitePath}: ${href}`)
+    }
+  })
+}

--- a/tests/build/site.redirects.test.js
+++ b/tests/build/site.redirects.test.js
@@ -1,0 +1,23 @@
+const test = require("node:test")
+const assert = require("node:assert/strict")
+const { getPage, readPublicText, SITE_URL, PREFIX } = require("./load")
+
+const redirects = [
+  { from: `${PREFIX}/is/`, to: `${PREFIX}` },
+  { from: `${PREFIX}/sv/is/`, to: `${PREFIX}/sv` },
+]
+
+for (const { from, to } of redirects) {
+  test(`client-side redirect page ${from} points to ${to}`, () => {
+    const page = getPage(from)
+    assert.ok(page, `redirect page not built: ${from}`)
+    assert.match(page.html, new RegExp(`window\\.location\\.href\\s*=\\s*"${to.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`))
+  })
+}
+
+test("Netlify _redirects file includes both legacy /is redirects", () => {
+  const text = readPublicText("_redirects")
+  assert.ok(text, "_redirects not found in public/")
+  assert.match(text, /\/terson\/is\s+\/terson\/?\s+302/)
+  assert.match(text, /\/terson\/sv\/is\s+\/terson\/sv\s+302/)
+})


### PR DESCRIPTION
## Summary

This PR adds a comprehensive test suite for verifying SEO correctness, build output integrity, and site-wide best practices. The suite runs against the real built output (not source code) and catches regressions in head metadata, structured data, internationalization, accessibility, and more.

## Key Changes

- **New test infrastructure** (`tests/build/load.js`): Utilities to walk the built `public/` directory, parse HTML/XML with cheerio, and provide helpers for URL resolution and asset existence checks.

- **SEO verification tests**:
  - `seo.head.test.js`: Validates title format, meta descriptions, Open Graph, Twitter cards, canonical links
  - `seo.jsonld.test.js`: Checks JSON-LD structured data (Person, BlogPosting, MusicRecording, VideoObject) for required fields and valid schema
  - `seo.sitemap.test.js`: Verifies sitemap-index.xml and sitemap-0.xml structure, hreflang alternates, priorities, and page coverage
  - `seo.article.test.js`: Article-specific checks (published_time, author, RSS feed links, og:video)
  - `seo.identity.test.js`: Ensures Person identity (@id, name) is consistent across all pages
  - `seo.hreflang.test.js`: Validates reciprocal hreflang alternates between English and Swedish pages
  - `seo.relme.test.js`: Verifies rel=me links match Person node's sameAs
  - `seo.og-images.test.js`: Checks og:image URLs are absolute, under site prefix, and files exist
  - `seo.robots-llms.test.js`: Validates robots.txt and llms.txt structure and link validity
  - `seo.manifest.test.js`: Checks manifest.webmanifest validity and icon/start_url resolution
  - `seo.rss.test.js`: Validates RSS feed XML structure, item metadata, and language filtering

- **Site hygiene tests**:
  - `site.hygiene.test.js`: Detects stringified leaks (undefined, null, NaN, [object Object]) in head and body
  - `site.images.test.js`: Ensures all `<img>` tags have alt text and src files exist; checks responsive image markup
  - `site.links.test.js`: Verifies all internal links resolve to built pages
  - `site.i18n.test.js`: Confirms correct language strings render and no interpolation placeholders leak
  - `site.css-purge.test.js`: Validates PurgeCSS safelist preserves Ghost/markdown content classes
  - `site.redirects.test.js`: Checks client-side redirects and Netlify _redirects file
  - `site.404.test.js`: Validates 404 page title and content

- **Build correctness tests**:
  - `seo.pages-exist.test.js`: Ensures core pages exist and no duplicate titles; validates article page count

- **Core pages registry** (`core-pages.js`): Defines expected pages for validation.

- **Skill documentation** (`.claude/skills/verify/SKILL.md`): Explains when and how to run the verification suite.

- **Minor source fixes**:
  - `src/pages/404.js`: Refactored to use `getFixedT()` instead of mutating shared i18next state
  - `src/pages/engineers/a-tableau-web-data-connector-generator.js`: Added `withPrefix` import for proper path handling
  - `src/components/seo.js`: Fixed og:image URL generation to ensure absolute URLs with proper prefix handling
  - `gatsby-config.js`: Corrected manifest `start_url` to account for gatsby-plugin-manifest's pathPrefix handling

- **Dependencies**: Added `cheerio` for HTML/XML parsing in tests.

## Implementation Details

- Tests use Node's built-in `test` runner (no external test framework)
- All tests run against real parsed HTML/XML from `public/`, not source code
- Tests are organized by concern (SEO, site hygiene,

https://claude.ai/code/session_0176H6sh1g7XUu5aAzVzncFC