### PR TITLE
Fix sitemap hreflang alternates to only advertise existing pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,9 @@ const urljoin = require("url-join")
 const siteConfig = require("./siteConfig")
 const getSlugForPost = require("./src/utils/i18n-urls").getSlugForPost
 
+// Shared between the sitemap plugin's resolvePages and serialize hooks below.
+let sitemapPaths
+
 module.exports = {
   pathPrefix: siteConfig.prefix,
   siteMetadata: {
@@ -183,10 +186,24 @@ module.exports = {
           }
         `,
         resolveSiteUrl: () => urljoin(siteConfig.url, siteConfig.prefix),
+        // Populated by resolvePages, read by serialize: the set of built paths
+        // (trailing-slash normalized) that are actually going into the sitemap.
+        // Used so we only advertise an hreflang alternate when that translated
+        // page genuinely exists, instead of pointing crawlers at 404s.
         resolvePages: ({ allSitePage: { nodes: allPages } }) => {
-          return allPages.filter(({ path }) => {
-            return !path.includes(`/404`) && !path.includes(`/dev-404`)
+          const filtered = allPages.filter(({ path }) => {
+            return (
+              !path.includes(`/404`) &&
+              !path.includes(`/dev-404`) &&
+              // /is and /sv/is are legacy client-side redirect stubs, not
+              // content; they shouldn't be advertised for indexing.
+              !/\/is\/?$/.test(path)
+            )
           })
+          sitemapPaths = new Set(
+            filtered.map(({ path }) => (path.endsWith(`/`) ? path : `${path}/`))
+          )
+          return filtered
         },
         serialize: ({ path }) => {
           const siteUrl = urljoin(siteConfig.url, siteConfig.prefix)
@@ -196,6 +213,13 @@ module.exports = {
             ? withTrailing.replace(/^\/sv/, ``) || `/`
             : withTrailing
           const svPath = isSv ? withTrailing : `/sv${withTrailing}`
+          const links = [{ lang: `x-default`, url: `${siteUrl}/` }]
+          if (sitemapPaths.has(enPath)) {
+            links.push({ lang: `en`, url: `${siteUrl}${enPath}` })
+          }
+          if (sitemapPaths.has(svPath)) {
+            links.push({ lang: `sv`, url: `${siteUrl}${svPath}` })
+          }
           return {
             // Relative path; with --prefix-paths the plugin prepends /terson correctly.
             // Local builds without --prefix-paths will have wrong page URLs in the
@@ -204,11 +228,7 @@ module.exports = {
             changefreq: `monthly`,
             priority:
               path === `/` || path === `/sv` || path === `/sv/` ? 1.0 : 0.7,
-            links: [
-              { lang: `x-default`, url: `${siteUrl}/` },
-              { lang: `en`, url: `${siteUrl}${enPath}` },
-              { lang: `sv`, url: `${siteUrl}${svPath}` },
-            ],
+            links,
           }
         },
       },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,39 +5,37 @@ const { getSlugForPost } = require("./src/utils/i18n-urls")
 exports.createPages = ({ graphql, actions }) => {
   const { createPage, createRedirect } = actions
 
-  // Static redirects
+  // Static redirects. Permanent (301) so search engines consolidate the
+  // legacy URLs into the target rather than parking both as indexable.
   createRedirect({
     fromPath: "/is",
     toPath: "/",
+    isPermanent: true,
   })
   createRedirect({
     fromPath: "/sv/is",
     toPath: "/sv",
+    isPermanent: true,
   })
 
   const blogPost = path.resolve(`./src/templates/blog-post.js`)
-  return graphql(
-    `
-      {
-        allMarkdownRemark(
-          sort: { frontmatter: { date: DESC } }
-          limit: 1000
-        ) {
-          edges {
-            node {
-              fields {
-                slug
-              }
-              frontmatter {
-                title
-                langKey
-              }
+  return graphql(`
+    {
+      allMarkdownRemark(sort: { frontmatter: { date: DESC } }, limit: 1000) {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              langKey
             }
           }
         }
       }
-    `
-  ).then(result => {
+    }
+  `).then((result) => {
     if (result.errors) {
       throw result.errors
     }
@@ -97,5 +95,7 @@ exports.onPostBuild = async ({ reporter }) => {
     `${siteUrl}/sitemap-`
   )
   fs.writeFileSync(indexPath, content)
-  reporter.info(`[sitemap] Fixed sitemap-index.xml references to use ${siteUrl}`)
+  reporter.info(
+    `[sitemap] Fixed sitemap-index.xml references to use ${siteUrl}`
+  )
 }

--- a/src/pages/engineers/a-tableau-web-data-connector-generator.js
+++ b/src/pages/engineers/a-tableau-web-data-connector-generator.js
@@ -375,17 +375,13 @@ const LegacyWdcGeneratorPage = ({ data, location }) => {
 export default LegacyWdcGeneratorPage
 
 export function Head({ data }) {
+  const { siteUrl } = data.site.siteMetadata
   return (
     <Seo
       title="Yo, Tableau Web Data Connector!"
-      keywords={[
-        `Tableau`,
-        `WDC`,
-        `Web Data Connector`,
-        `Generator`,
-        `Yeoman`,
-      ]}
+      keywords={[`Tableau`, `WDC`, `Web Data Connector`, `Generator`, `Yeoman`]}
       img={getSrc(data.yoTableauDataConnector)}
+      canonical={`${siteUrl}/engineers/a-tableau-web-data-connector-generator/`}
     />
   )
 }
@@ -395,6 +391,7 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
+        siteUrl
       }
     }
     yoTableauDataConnector: file(

--- a/src/pages/engineers/better-wdc-performance-with-promises.js
+++ b/src/pages/engineers/better-wdc-performance-with-promises.js
@@ -422,6 +422,7 @@ Promise.all(allPromisesFor('https://api.example.com', [1, 2, 3])
 export default LegacyWdcPromisesPage
 
 export function Head({ data }) {
+  const { siteUrl } = data.site.siteMetadata
   return (
     <Seo
       title="Better WDC Performance with Promises"
@@ -433,6 +434,7 @@ export function Head({ data }) {
         `Promise`,
       ]}
       img={getSrc(data.promises)}
+      canonical={`${siteUrl}/engineers/better-wdc-performance-with-promises/`}
     />
   )
 }
@@ -442,6 +444,7 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
+        siteUrl
       }
     }
     promises: file(relativePath: { eq: "legacy/promises.jpg" }) {

--- a/src/pages/sv/writes/a-response-to-sou-2025-1.js
+++ b/src/pages/sv/writes/a-response-to-sou-2025-1.js
@@ -216,17 +216,14 @@ const StaticSou20251ResponsePage = ({ data, location }) => {
 export default StaticSou20251ResponsePage
 
 export function Head({ data }) {
+  const { siteUrl } = data.site.siteMetadata
   return (
     <Seo
       title="Remissvar över betänkandet SOU 2025:1 Utredningen om skärpta krav för att förvärva svenskt medborgarskap"
-      keywords={[
-        `Sverige`,
-        `Medborgarskap`,
-        `Tech`,
-        `Arbetskraftsinvandring`,
-      ]}
+      keywords={[`Sverige`, `Medborgarskap`, `Tech`, `Arbetskraftsinvandring`]}
       lang="sv-SE"
       img={getSrc(data.svenskaFlaggan)}
+      canonical={`${siteUrl}/sv/writes/a-response-to-sou-2025-1/`}
     />
   )
 }
@@ -236,6 +233,7 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
+        siteUrl
       }
     }
     svenskaFlaggan: file(

--- a/src/pages/writes/a-response-to-sou-2025-1.js
+++ b/src/pages/writes/a-response-to-sou-2025-1.js
@@ -211,11 +211,13 @@ const StaticSou20251ResponsePage = ({ data, location }) => {
 export default StaticSou20251ResponsePage
 
 export function Head({ data }) {
+  const { siteUrl } = data.site.siteMetadata
   return (
     <Seo
       title="Response to the inquiry into stricter requirements for acquiring Swedish citizenship"
       keywords={[`Sweden`, `Citizenship`, `Tech`, `Labor Migration`]}
       img={getSrc(data.svenskaFlaggan)}
+      canonical={`${siteUrl}/writes/a-response-to-sou-2025-1/`}
     />
   )
 }
@@ -225,6 +227,7 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
+        siteUrl
       }
     }
     svenskaFlaggan: file(

--- a/tests/build/seo.head.test.js
+++ b/tests/build/seo.head.test.js
@@ -29,23 +29,35 @@ for (const page of pages) {
     )
     assert.equal(meta($, "name", "twitter:site").attr("content"), "@iamEAP")
     assert.equal(meta($, "name", "twitter:creator").attr("content"), "@iamEAP")
-    for (const name of ["twitter:title", "twitter:description", "twitter:image"]) {
+    for (const name of [
+      "twitter:title",
+      "twitter:description",
+      "twitter:image",
+    ]) {
       assert.ok(meta($, "name", name).length, `missing ${name}`)
     }
   })
 
   test(`${sitePath}: html lang is set`, () => {
     const lang = $("html").attr("lang")
-    assert.ok(lang === "en-US" || lang === "sv-SE" || lang === "en", `got "${lang}"`)
+    assert.ok(
+      lang === "en-US" || lang === "sv-SE" || lang === "en",
+      `got "${lang}"`
+    )
   })
 
   const canonical = $('link[rel="canonical"]').attr("href")
-  if (canonical) {
-    test(`${sitePath}: canonical is absolute, under ${SITE_URL}, trailing slash`, () => {
+  const isNotFoundPage = sitePath.includes("/404")
+
+  if (!isNotFoundPage) {
+    test(`${sitePath}: has a canonical link, absolute, under ${SITE_URL}, trailing slash`, () => {
+      assert.ok(canonical, 'missing <link rel="canonical">')
       assert.ok(canonical.startsWith(SITE_URL))
       assert.ok(canonical.endsWith("/"))
     })
+  }
 
+  if (canonical) {
     test(`${sitePath}: og:url matches canonical when present`, () => {
       const ogUrl = meta($, "property", "og:url").attr("content")
       if (ogUrl) assert.equal(ogUrl, canonical)

--- a/tests/build/seo.sitemap.test.js
+++ b/tests/build/seo.sitemap.test.js
@@ -56,6 +56,21 @@ test("every sitemap url resolves to a page that was actually built", () => {
   })
 })
 
+test("every hreflang alternate href resolves to a page that was actually built", () => {
+  // Directly guards the failure mode where a page advertises a translated
+  // alternate (e.g. an /sv/... twin) that was never built. Checked against
+  // disk rather than transitively via the <loc> set, so it stands on its own.
+  const $ = readPublicXml("sitemap-0.xml")
+  $("url xhtml\\:link").each((_, el) => {
+    const href = $(el).attr("href")
+    const hreflang = $(el).attr("hreflang")
+    assert.ok(
+      assetExists(href),
+      `hreflang=${hreflang} alternate points at a non-existent page: ${href}`
+    )
+  })
+})
+
 test("every sitemap url has an x-default hreflang alternate, and every alternate it does advertise resolves to a URL also in the sitemap", () => {
   const $ = readPublicXml("sitemap-0.xml")
   const allLocs = new Set(

--- a/tests/build/seo.sitemap.test.js
+++ b/tests/build/seo.sitemap.test.js
@@ -23,6 +23,19 @@ test("sitemap-0.xml is valid and excludes 404 pages", () => {
   }
 })
 
+test("sitemap-0.xml excludes the legacy /is and /sv/is redirect stubs", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  const urls = $("url > loc")
+    .map((_, el) => $(el).text())
+    .get()
+  for (const url of urls) {
+    assert.ok(
+      !/\/is\/?$/.test(url),
+      `sitemap should not include the redirect stub: ${url}`
+    )
+  }
+})
+
 test("every sitemap url is absolute, under the site prefix, and has a trailing slash", () => {
   const $ = readPublicXml("sitemap-0.xml")
   $("url > loc").each((_, el) => {
@@ -36,21 +49,70 @@ test("every sitemap url resolves to a page that was actually built", () => {
   const $ = readPublicXml("sitemap-0.xml")
   $("url > loc").each((_, el) => {
     const url = $(el).text()
-    assert.ok(assetExists(url), `sitemap references a non-existent page: ${url}`)
+    assert.ok(
+      assetExists(url),
+      `sitemap references a non-existent page: ${url}`
+    )
   })
 })
 
-test("every sitemap url has x-default/en/sv hreflang alternates", () => {
+test("every sitemap url has an x-default hreflang alternate, and every alternate it does advertise resolves to a URL also in the sitemap", () => {
   const $ = readPublicXml("sitemap-0.xml")
+  const allLocs = new Set(
+    $("url > loc")
+      .map((_, el) => $(el).text())
+      .get()
+  )
   $("url").each((_, urlEl) => {
-    const langs = $(urlEl)
+    const loc = $(urlEl).find("loc").text()
+    const links = $(urlEl).find("xhtml\\:link")
+    const langs = links.map((_, el) => $(el).attr("hreflang")).get()
+    assert.ok(langs.includes("x-default"), `${loc} missing hreflang=x-default`)
+    links.each((_, el) => {
+      const hreflang = $(el).attr("hreflang")
+      if (hreflang === "x-default") return
+      const href = $(el).attr("href")
+      assert.ok(
+        allLocs.has(href),
+        `${loc}: hreflang=${hreflang} alternate ${href} isn't a page in the sitemap`
+      )
+    })
+  })
+})
+
+test("translated pairs (home, posts, sou-2025-1 writeup) advertise both en and sv alternates", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  const translatedLocs = [
+    `${SITE_URL}/`,
+    `${SITE_URL}/posts/`,
+    `${SITE_URL}/writes/a-response-to-sou-2025-1/`,
+  ]
+  for (const loc of translatedLocs) {
+    const urlEl = $("url").filter((_, el) => $(el).find("loc").text() === loc)
+    assert.ok(urlEl.length, `${loc} not found in sitemap`)
+    const langs = urlEl
       .find("xhtml\\:link")
       .map((_, el) => $(el).attr("hreflang"))
       .get()
     for (const lang of ["x-default", "en", "sv"]) {
-      assert.ok(langs.includes(lang), `${$(urlEl).find("loc").text()} missing hreflang=${lang}`)
+      assert.ok(langs.includes(lang), `${loc} missing hreflang=${lang}`)
     }
-  })
+  }
+})
+
+test("untranslated legacy pages don't advertise a nonexistent sv alternate", () => {
+  const $ = readPublicXml("sitemap-0.xml")
+  const loc = `${SITE_URL}/engineers/a-tableau-web-data-connector-generator/`
+  const urlEl = $("url").filter((_, el) => $(el).find("loc").text() === loc)
+  assert.ok(urlEl.length, `${loc} not found in sitemap`)
+  const langs = urlEl
+    .find("xhtml\\:link")
+    .map((_, el) => $(el).attr("hreflang"))
+    .get()
+  assert.ok(
+    !langs.includes("sv"),
+    `${loc} should not advertise an sv alternate; no sv translation exists`
+  )
 })
 
 test("homepage has priority 1.0; other pages have a lower priority", () => {
@@ -59,7 +121,11 @@ test("homepage has priority 1.0; other pages have a lower priority", () => {
     const loc = $(urlEl).find("loc").text()
     const priority = $(urlEl).find("priority").text()
     const isHome = loc === `${SITE_URL}/` || loc === `${SITE_URL}/sv/`
-    assert.equal(priority, isHome ? "1.0" : "0.7", `unexpected priority for ${loc}`)
+    assert.equal(
+      priority,
+      isHome ? "1.0" : "0.7",
+      `unexpected priority for ${loc}`
+    )
   })
 })
 
@@ -72,5 +138,8 @@ test("core built pages are represented in the sitemap", () => {
   )
   const articlePage = pages.find((p) => p.isArticle)
   assert.ok(articlePage, "no article pages to check against the sitemap")
-  assert.ok(urls.has(articlePage.url), `${articlePage.url} missing from sitemap`)
+  assert.ok(
+    urls.has(articlePage.url),
+    `${articlePage.url} missing from sitemap`
+  )
 })

--- a/tests/build/site.redirects.test.js
+++ b/tests/build/site.redirects.test.js
@@ -11,13 +11,18 @@ for (const { from, to } of redirects) {
   test(`client-side redirect page ${from} points to ${to}`, () => {
     const page = getPage(from)
     assert.ok(page, `redirect page not built: ${from}`)
-    assert.match(page.html, new RegExp(`window\\.location\\.href\\s*=\\s*"${to.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`))
+    assert.match(
+      page.html,
+      new RegExp(
+        `window\\.location\\.href\\s*=\\s*"${to.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`
+      )
+    )
   })
 }
 
-test("Netlify _redirects file includes both legacy /is redirects", () => {
+test("Netlify _redirects file includes both legacy /is redirects as permanent (301)", () => {
   const text = readPublicText("_redirects")
   assert.ok(text, "_redirects not found in public/")
-  assert.match(text, /\/terson\/is\s+\/terson\/?\s+302/)
-  assert.match(text, /\/terson\/sv\/is\s+\/terson\/sv\s+302/)
+  assert.match(text, /\/terson\/is\s+\/terson\/?\s+301/)
+  assert.match(text, /\/terson\/sv\/is\s+\/terson\/sv\s+301/)
 })


### PR DESCRIPTION
## Summary
This PR improves SEO by ensuring the sitemap only advertises hreflang alternates for pages that actually exist, preventing crawlers from being directed to 404s. It also marks legacy redirect stubs as non-indexable and converts their redirects to permanent (301) status codes.

## Key Changes

- **Sitemap hreflang validation**: Modified the sitemap serialization logic to track which pages are actually being included in the sitemap, then only advertise language alternates (`en`, `sv`) when those translated versions genuinely exist. The `x-default` alternate always points to the homepage.

- **Exclude redirect stubs from sitemap**: Added filtering to prevent the legacy `/is` and `/sv/is` client-side redirect stub pages from appearing in the sitemap, since they're not actual content.

- **Permanent redirects**: Changed the `/is` and `/sv/is` redirects from temporary (302) to permanent (301) status codes so search engines consolidate the legacy URLs into the target pages rather than indexing both.

- **Canonical tags on legacy pages**: Added explicit canonical tags to untranslated legacy pages (`a-tableau-web-data-connector-generator`, `better-wdc-performance-with-promises`, and the English version of `a-response-to-sou-2025-1`) to clarify their canonical URLs.

- **Enhanced test coverage**: 
  - New test to verify redirect stubs are excluded from the sitemap
  - Refactored hreflang test to validate that advertised alternates actually exist in the sitemap
  - New tests for translated page pairs (home, posts, writeup) to ensure they advertise both `en` and `sv` alternates
  - New test for untranslated pages to ensure they don't advertise non-existent `sv` alternates
  - Updated redirect tests to expect 301 status codes instead of 302

## Implementation Details

The sitemap plugin's `resolvePages` hook now populates a shared `sitemapPaths` Set containing all normalized paths that will be included in the sitemap. The `serialize` hook then uses this Set to conditionally add language alternates only when the corresponding translated page exists, preventing broken hreflang references.

https://claude.ai/code/session_01EtVv9nSqTku7KUVRwjXSee