### PR TITLE
Style post card titles with image and add mobile responsive rules

### DIFF
--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -559,6 +559,21 @@ body {
   transition: all 0.3s cubic-bezier(0.33, 0, 0.2, 1);
 }
 
+.post-card.with-image .post-card-title {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+@media (max-width: 700px) {
+  .post-card.with-image .post-card-title {
+    font-size: 1.8rem;
+    max-width: 90%;
+    -webkit-line-clamp: 4;
+  }
+}
+
 /* Posts without images */
 .post-card.no-image:before {
   display: block;

--- a/src/utils/css/screen.css
+++ b/src/utils/css/screen.css
@@ -564,6 +564,7 @@ body {
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.85), 0 2px 14px rgba(0, 0, 0, 0.5);
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
Added CSS styling for post card titles when displayed with images, including text clamping and shadow effects, along with responsive adjustments for mobile devices.

## Key Changes
- Added `.post-card.with-image .post-card-title` styles with:
  - 3-line text clamping using `-webkit-line-clamp`
  - Text shadow for improved readability over images
  - Flexbox display configuration for proper text truncation
- Added mobile responsive rules (max-width: 700px) that:
  - Increase font size to 1.8rem for better mobile readability
  - Limit title width to 90% of container
  - Extend line clamp to 4 lines on smaller screens

## Implementation Details
- Uses `-webkit-box` display with `-webkit-box-orient: vertical` for cross-browser text clamping support
- Text shadow uses two layers (0 1px 4px and 0 2px 14px) for enhanced contrast against background images
- Mobile breakpoint at 700px ensures proper display on tablet and smaller devices

https://claude.ai/code/session_01XEf2rYinmUxuc4WULVr8pp