### PR TITLE
Fix hreflang alternates to point to live pages instead of redirects

### DIFF
--- a/src/pages/index.sv.tsx
+++ b/src/pages/index.sv.tsx
@@ -199,7 +199,7 @@ export default AboutPage
 
 export const Head = ({ data }: HeadProps<Queries.HomePageSvQuery>) => {
   const siteUrl = data.site?.siteMetadata?.siteUrl ?? ""
-  const canonical = `${siteUrl}/sv/is/`
+  const canonical = `${siteUrl}/sv/`
   const sameAs = [
     "https://twitter.com/iamEAP",
     "https://github.com/iamEAP",
@@ -227,7 +227,7 @@ export const Head = ({ data }: HeadProps<Queries.HomePageSvQuery>) => {
         link={[
           {
             rel: "alternate",
-            href: `${siteUrl}/is/`,
+            href: `${siteUrl}/`,
             hrefLang: "en",
           },
           ...sameAs.map((href) => ({ rel: "me", href })),

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -225,7 +225,7 @@ export const Head = ({ data }: HeadProps<Queries.HomePageQuery>) => {
         link={[
           {
             rel: "alternate",
-            href: `${siteUrl}/sv/is/`,
+            href: `${siteUrl}/sv/`,
             hrefLang: "sv",
           },
           ...sameAs.map((href) => ({ rel: "me", href })),

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -212,8 +212,14 @@ export const Head = ({
   const baseUrl = siteMeta?.baseUrl ?? ""
   const author = siteMeta?.author ?? ""
   const langKey = post?.frontmatter?.langKey === "sv" ? "sv" : "en"
-  // slug from Gatsby already has a trailing slash, strip it before we re-add one
-  const slugWithoutLeadingSlash = pageContext.slug.replace(/^\/|\/$/g, "")
+  // slug from Gatsby already has a trailing slash, strip it before we re-add one.
+  // Swedish posts come from `index.sv.md`, so their generated slug carries an
+  // `index.sv` segment (e.g. /foo/index.sv/). Strip it the same way page
+  // creation does (see getSlugForPost) so the canonical, og:url, and hreflang
+  // alternates resolve to the real page path (/sv/foo/) instead of a 404.
+  const slugWithoutLeadingSlash = pageContext.slug
+    .replace(`index.${langKey}/`, "")
+    .replace(/^\/|\/$/g, "")
   const canonical = `${siteUrl}/${langKey === "sv" ? `sv/${slugWithoutLeadingSlash}` : slugWithoutLeadingSlash}/`
   const thumbnail = post?.frontmatter?.thumbnail
   const ogImage = thumbnail ? `${baseUrl}${srcOf(thumbnail)}` : undefined

--- a/tests/build/seo.canonical.test.ts
+++ b/tests/build/seo.canonical.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { contentPages, getPage, assetExists, ORIGIN } from "./load.ts"
+
+// Regression guard for the Bing-scan class of bugs: a page can have a
+// perfectly well-formed canonical/hreflang tag that nonetheless points at a
+// URL with no page behind it, or at a redirect stub. `seo.head.test.ts` only
+// checks the canonical is present/absolute/trailing-slashed, and
+// `site.links.test.ts` only validates <a href> links — so neither caught the
+// Swedish posts canonicalizing to /sv/.../index.sv/ (a 404) or the home pages
+// pointing canonical/hreflang at the /is/ redirect stubs. These assertions do.
+
+// Maps an absolute URL (under our origin) to the site path getPage() expects.
+function toSitePath(url: string): string {
+  return url.startsWith(ORIGIN) ? url.slice(ORIGIN.length) : url
+}
+
+for (const page of contentPages) {
+  const { $, sitePath, url } = page
+
+  // The 404 page is intentionally not canonicalized or indexed (mirrors the
+  // isNotFoundPage carve-out in seo.head.test.ts).
+  if (sitePath.includes("/404")) continue
+
+  const canonical = $('link[rel="canonical"]').attr("href")
+
+  test(`${sitePath}: canonical is self-referential (points at this page's own URL)`, () => {
+    assert.ok(canonical, 'missing <link rel="canonical">')
+    // A content page must canonicalize to itself. Catches the index.sv/ slug
+    // leak (canonical resolved to a sibling 404) and the /sv/ home page that
+    // declared /sv/is/ (a redirect stub) as its canonical.
+    assert.equal(
+      canonical,
+      url,
+      `canonical should equal own URL ${url}, got ${canonical}`
+    )
+  })
+
+  test(`${sitePath}: canonical resolves to a built, non-redirect page`, () => {
+    if (!canonical) return
+    assert.ok(assetExists(canonical), `canonical 404s: ${canonical}`)
+    const target = getPage(toSitePath(canonical))
+    assert.ok(
+      !target?.isInfra,
+      `canonical points at a redirect/infra stub: ${canonical}`
+    )
+  })
+
+  const alternates = $('link[rel="alternate"][hreflang]')
+    .map((_, el) => $(el).attr("href"))
+    .get()
+
+  if (alternates.length) {
+    test(`${sitePath}: every hreflang alternate resolves to a built, non-redirect page`, () => {
+      for (const href of alternates) {
+        assert.ok(href, "empty hreflang href")
+        assert.ok(assetExists(href), `hreflang alternate 404s: ${href}`)
+        const target = getPage(toSitePath(href))
+        assert.ok(
+          !target?.isInfra,
+          `hreflang alternate points at a redirect/infra stub: ${href}`
+        )
+      }
+    })
+  }
+}

--- a/tests/build/seo.hreflang.test.ts
+++ b/tests/build/seo.hreflang.test.ts
@@ -2,15 +2,16 @@ import test from "node:test"
 import assert from "node:assert/strict"
 import { getPage, SITE_URL, PREFIX } from "./load.ts"
 
-// The about pages intentionally point hreflang alternates at the legacy
-// "/is" redirect slugs rather than "/" and "/sv/" directly; that's existing,
-// deliberate behavior (see gatsby-node.js createRedirect), not a bug.
+// Home pages point hreflang alternates (and their own canonical) at the real
+// "/" and "/sv/" URLs, not the legacy "/is" redirect stubs. Pointing crawlers
+// at a redirect stub (which has no canonical content, H1, or meta description)
+// made Bing flag /sv/is/ as broken, so the alternates resolve to live pages.
 const pairs = [
   {
     en: `${PREFIX}/`,
     sv: `${PREFIX}/sv/`,
-    enAlternateHref: `${SITE_URL}/sv/is/`,
-    svAlternateHref: `${SITE_URL}/is/`,
+    enAlternateHref: `${SITE_URL}/sv/`,
+    svAlternateHref: `${SITE_URL}/`,
   },
   {
     en: `${PREFIX}/posts/`,


### PR DESCRIPTION
## Summary
This PR fixes hreflang alternate links and canonical URLs to point directly to live pages instead of legacy redirect stubs. This resolves issues where search engines like Bing were flagging redirect pages as broken due to missing canonical content, H1 tags, and meta descriptions.

## Key Changes
- **Home pages**: Updated canonical and hreflang alternate URLs to use the real `/` and `/sv/` paths instead of the legacy `/is/` and `/sv/is/` redirect stubs
- **Blog posts**: Fixed slug processing to strip the `index.{langKey}` segment from Swedish post slugs (e.g., `/foo/index.sv/` → `/sv/foo/`) so canonical, og:url, and hreflang alternates resolve to actual page paths instead of 404s
- **Test expectations**: Updated hreflang test pairs to reflect the corrected URL structure

## Implementation Details
- The blog post slug fix handles the fact that Swedish posts are generated from `index.sv.md` files, which creates slugs with an `index.sv` segment that needs to be stripped before constructing the final canonical URL
- The fix ensures consistency between how page slugs are created (in `getSlugForPost`) and how they're used in the Head component for SEO metadata

https://claude.ai/code/session_01BmxBY2WWa7quSspF8qsZpf